### PR TITLE
Supports a full ActionRequest via command line/SDK

### DIFF
--- a/globus_automate_client/action_client.py
+++ b/globus_automate_client/action_client.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, Dict, Optional, Mapping
+from typing import Any, Dict, Iterable, Mapping, Optional
 
 import requests
 from globus_sdk import (
@@ -51,7 +51,11 @@ class ActionClient(BaseClient):
         return self.default_response_class(resp, client=self)
 
     def run(
-        self, body: Mapping[str, Any], request_id: Optional[str] = None
+        self,
+        body: Mapping[str, Any],
+        request_id: Optional[str] = None,
+        manage_by: Optional[Iterable[str]] = None,
+        monitor_by: Optional[Iterable[str]] = None,
     ) -> GlobusHTTPResponse:
         """
         Invoke the Action Provider to execute an Action with the given
@@ -61,11 +65,25 @@ class ActionClient(BaseClient):
             Action payload
         :param request_id: An optional identifier that serves to de-deplicate
             requests to the Action Provider
+        :param manage_by: A series of Globus identities which may alter
+            this Action's execution
+        :param monitor_by: A series of Globus identities which may
+            view the state of this Action
         """
         if request_id is None:
             request_id = str(uuid.uuid4())
+        if manage_by is not None:
+            manage_by = list(set(manage_by))
+        if monitor_by is not None:
+            monitor_by = list(set(monitor_by))
+
         path = self.qjoin_path("run")
-        body = {"request_id": str(request_id), "body": body}
+        body = {
+            "request_id": str(request_id),
+            "body": body,
+            "monitor_by": monitor_by,
+            "manage_by": manage_by,
+        }
         return self.post(path, body)
 
     def status(self, action_id: str) -> GlobusHTTPResponse:

--- a/globus_automate_client/cli/actions.py
+++ b/globus_automate_client/cli/actions.py
@@ -1,11 +1,13 @@
 import json
 import uuid
+from typing import List
 
 import typer
 
 from globus_automate_client.action_client import create_action_client
 from globus_automate_client.cli.callbacks import (
     json_validator_callback,
+    principal_validator_callback,
     url_validator_callback,
 )
 from globus_automate_client.cli.helpers import format_and_echo, verbosity_option
@@ -65,6 +67,16 @@ def action_run(
     request_id: str = typer.Option(
         None, help=("An identifier to associate with this Action invocation request"),
     ),
+    manage_by: List[str] = typer.Option(
+        None,
+        help="A principal which may change the execution of the Action. [repeatable]",
+        callback=principal_validator_callback,
+    ),
+    monitor_by: List[str] = typer.Option(
+        None,
+        help="A principal which may view the state of the Action. [repeatable]",
+        callback=principal_validator_callback,
+    ),
     verbose: bool = verbosity_option,
 ):
     """
@@ -73,7 +85,7 @@ def action_run(
     ac = create_action_client(action_url, action_scope)
     if ac:
         parsed_body = json.loads(body)
-        result = ac.run(parsed_body, request_id)
+        result = ac.run(parsed_body, request_id, manage_by, monitor_by)
         format_and_echo(result, verbose=verbose)
     return None
 


### PR DESCRIPTION
Adds support for creating the full ActionRequest document to the SDK and CLI. 

Previously, when launching an Action, the only parameters that could be set on it were `request_id` and `body`. The full Action Request spec outlines that a `POST` to `/run` may also contain `manage_by` and `monitor_by` fields. Not specifying these was fine but it meant that if someone ever wanted to set/use them, they'd be unable to via the client. This change corrects that. 

[ch2113]