### PR TITLE
An input schema for the multi-transfer flow example

### DIFF
--- a/examples/flows/multi-transfer/input_schema.json
+++ b/examples/flows/multi-transfer/input_schema.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "source_endpoint_id",
+    "source_path",
+    "staging_endpoint_id",
+    "staging_path",
+    "destination_endpoint_id",
+    "destination_path"
+  ],
+  "properties": {
+    "source_endpoint_id": {
+      "type": "string"
+    },
+    "source_path": {
+      "type": "string"
+    },
+    "staging_endpoint_id": {
+      "type": "string"
+    },
+    "staging_path": {
+      "type": "string"
+    },
+    "destination_endpoint_id": {
+      "type": "string"
+    },
+    "destination_path": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
A simple schema for this Flow. Can be specified when deploying using the --input-schema option on the CLI.