### PR TITLE
Error on traversing flow definition for state names

### DIFF
--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -63,7 +63,7 @@ def _all_vals_for_keys(
             )
         elif isinstance(v, list):
             for val in v:
-                if isinstance(val, str):
+                if k in key_name_set and isinstance(v, str):
                     val_set.add(val)
                 elif isinstance(val, dict):
                     val_set.update(
@@ -106,6 +106,7 @@ def validate_flow_definition(flow_definition: Mapping[str, Any]) -> None:
         flow_definition,
         stop_traverse_key_set={"Parameters"},
     )
+
     unreferenced = state_names - flow_state_refs
     not_present = flow_state_refs - state_names
     if len(unreferenced) > 0:


### PR DESCRIPTION
The code didn't properly handle lists/arrays in the flow
definition (notably on `ErrorEquals` on a `Catch`).

Needed a check that the key being inspected is in the desired key set
before adding the array values into the return set.