### PR TITLE
Allows special values in principal validation

### DIFF
--- a/globus_automate_client/cli/actions.py
+++ b/globus_automate_client/cli/actions.py
@@ -7,7 +7,7 @@ import typer
 from globus_automate_client.action_client import create_action_client
 from globus_automate_client.cli.callbacks import (
     json_validator_callback,
-    principal_validator_callback,
+    principal_validator,
     url_validator_callback,
 )
 from globus_automate_client.cli.helpers import format_and_echo, verbosity_option
@@ -70,12 +70,12 @@ def action_run(
     manage_by: List[str] = typer.Option(
         None,
         help="A principal which may change the execution of the Action. [repeatable]",
-        callback=principal_validator_callback,
+        callback=principal_validator,
     ),
     monitor_by: List[str] = typer.Option(
         None,
         help="A principal which may view the state of the Action. [repeatable]",
-        callback=principal_validator_callback,
+        callback=principal_validator,
     ),
     verbose: bool = verbosity_option,
 ):

--- a/globus_automate_client/cli/actions.py
+++ b/globus_automate_client/cli/actions.py
@@ -65,7 +65,8 @@ def action_run(
         callback=json_validator_callback,
     ),
     request_id: str = typer.Option(
-        None, help=("An identifier to associate with this Action invocation request"),
+        None,
+        help=("An identifier to associate with this Action invocation request"),
     ),
     manage_by: List[str] = typer.Option(
         None,

--- a/globus_automate_client/cli/callbacks.py
+++ b/globus_automate_client/cli/callbacks.py
@@ -1,7 +1,7 @@
 import json
 import os
 import pathlib
-from typing import List, Optional
+from typing import AbstractSet, List
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -86,7 +86,7 @@ def text_validator_callback(message: str) -> str:
 
 
 def _base_principal_validator(
-    principals: List[str], *, special_vals=set()
+    principals: List[str], *, special_vals: AbstractSet[str] = frozenset()
 ) -> List[str]:
     """
     This validator ensures the principal IDs are valid UUIDs prefixed with valid
@@ -124,7 +124,7 @@ def principal_validator(principals: List[str]) -> List[str]:
     """
     A principal ID needs to be a valid UUID.
     """
-    return _base_principal_validator(principals, special_vals=None)
+    return _base_principal_validator(principals)
 
 
 def principal_or_all_authenticated_users_validator(principals: List[str]) -> List[str]:

--- a/globus_automate_client/cli/callbacks.py
+++ b/globus_automate_client/cli/callbacks.py
@@ -85,7 +85,7 @@ def text_validator_callback(message: str) -> str:
     return message
 
 
-def principal_validator_callback(principals: List[str]) -> List[str]:
+def principal_validator(principals: List[str]) -> List[str]:
     """
     A principal ID needs to be a valid UUID. This validator ensures the
     principal IDs are valid UUIDs.
@@ -111,6 +111,38 @@ def principal_validator_callback(principals: List[str]) -> List[str]:
                 f"Principal could not be parsed as a valid identifier: {p}"
             )
 
+    return principals
+
+
+def principal_or_all_authenticated_users_validator(principals: List[str]) -> List[str]:
+    """
+    Certain fields expect values to be a valid Globus Auth UUID or one of a set
+    of special strings that are meaningful in the context of authentication.
+    This callback is a specialized form of the principal_validator where the
+    special value of 'all_authenticated_users' is accepted.
+    """
+    special_vals = {"all_authenticated_users"}
+
+    for p in principals:
+        if p in special_vals:
+            continue
+        principal_validator([p])
+    return principals
+
+
+def principal_or_public_validator(principals: List[str]) -> List[str]:
+    """
+    Certain fields expect values to be a valid Globus Auth UUID or one of a set
+    of special strings that are meaningful in the context of authentication.
+    This callback is a specialized form of the principal_validator where the
+    special value of 'public' is accepted.
+    """
+    special_vals = {"public"}
+
+    for p in principals:
+        if p in special_vals:
+            continue
+        principal_validator([p])
     return principals
 
 

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -8,7 +8,9 @@ from globus_sdk import GlobusHTTPResponse
 from globus_automate_client.cli.callbacks import (
     flows_endpoint_envvar_callback,
     json_validator_callback,
-    principal_validator_callback,
+    principal_or_all_authenticated_users_validator,
+    principal_or_public_validator,
+    principal_validator,
     url_validator_callback,
 )
 from globus_automate_client.cli.helpers import (
@@ -103,18 +105,26 @@ def flow_deploy(
     ),
     visible_to: List[str] = typer.Option(
         None,
-        help="A principal which may see the existence of deployed Flow. [repeatable]",
-        callback=principal_validator_callback,
+        help=(
+            "A principal which may see the existence of the deployed Flow. The "
+            'special value of "public" may be used to control which users can '
+            "discover this flow. [repeatable]"
+        ),
+        callback=principal_or_public_validator,
     ),
     administered_by: List[str] = typer.Option(
         None,
         help="A principal which may update the deployed Flow. [repeatable]",
-        callback=principal_validator_callback,
+        callback=principal_validator,
     ),
     runnable_by: List[str] = typer.Option(
         None,
-        help="A principal which may run an instance of the deployed Flow. [repeatable]",
-        callback=principal_validator_callback,
+        help=(
+            "A principal which may run an instance of the deployed Flow. The special "
+            'value of "all_authenticated_users" may be used to control which users '
+            "can invoke this flow. [repeatable]"
+        ),
+        callback=principal_or_all_authenticated_users_validator,
     ),
     validate: bool = typer.Option(
         True,
@@ -186,18 +196,26 @@ def flow_update(
     ),
     visible_to: List[str] = typer.Option(
         None,
-        help="A principal which may see the existence of deployed Flow. [repeatable]",
-        callback=principal_validator_callback,
+        help=(
+            "A principal which may see the existence of the deployed Flow. The "
+            'special value of "public" may be used to control which users can '
+            "discover this flow. [repeatable]"
+        ),
+        callback=principal_or_public_validator,
     ),
     administered_by: List[str] = typer.Option(
         None,
         help="A principal which may update the deployed Flow. [repeatable]",
-        callback=principal_validator_callback,
+        callback=principal_validator,
     ),
     runnable_by: List[str] = typer.Option(
         None,
-        help="A principal which may run an instance of the deployed Flow. [repeatable]",
-        callback=principal_validator_callback,
+        help=(
+            "A principal which may run an instance of the deployed Flow. The special "
+            'value of "all_authenticated_users" may be used to control which users '
+            "can invoke this flow. [repeatable]"
+        ),
+        callback=principal_or_all_authenticated_users_validator,
     ),
     validate: bool = typer.Option(
         True,

--- a/globus_automate_client/cli/queues.py
+++ b/globus_automate_client/cli/queues.py
@@ -4,7 +4,7 @@ from typing import List
 import typer
 
 from globus_automate_client.cli.callbacks import (
-    principal_validator_callback,
+    principal_validator,
     text_validator_callback,
 )
 from globus_automate_client.cli.helpers import format_and_echo, verbosity_option
@@ -48,19 +48,19 @@ def queue_create(
         ...,
         "--admin",
         help="The Principal URNs allowed to administer the Queue. [repeatable]",
-        callback=principal_validator_callback,
+        callback=principal_validator,
     ),
     senders: List[str] = typer.Option(
         ...,
         "--sender",
         help="The Principal URNs allowed to send to the Queue. [repeatable]",
-        callback=principal_validator_callback,
+        callback=principal_validator,
     ),
     receivers: List[str] = typer.Option(
         ...,
         "--receiver",
         help="The Principal URNs allowed to receive from the Queue. [repeatable]",
-        callback=principal_validator_callback,
+        callback=principal_validator,
     ),
     verbose: bool = verbosity_option,
 ):
@@ -80,19 +80,19 @@ def queue_update(
         ...,
         "--admin",
         help="The Principal URNs allowed to administer the Queue. [repeatable]",
-        callback=principal_validator_callback,
+        callback=principal_validator,
     ),
     senders: List[str] = typer.Option(
         ...,
         "--sender",
         help="The Principal URNs allowed to send to the Queue. [repeatable]",
-        callback=principal_validator_callback,
+        callback=principal_validator,
     ),
     receivers: List[str] = typer.Option(
         ...,
         "--receiver",
         help="The Principal URNs allowed to receive from the Queue. [repeatable]",
-        callback=principal_validator_callback,
+        callback=principal_validator,
     ),
     delivery_timeout: int = typer.Option(
         ...,


### PR DESCRIPTION
This fix essentially adds a second principal validator callback that accepts "public" and a third principal validator callback that accepts "all_authenticated_users" as valid values. These new callbacks use the old callback for validation if the principal is not one of the special values. [ch3716]