### PR TITLE
Removes False-y values from action_run body

### DIFF
--- a/globus_automate_client/action_client.py
+++ b/globus_automate_client/action_client.py
@@ -84,6 +84,8 @@ class ActionClient(BaseClient):
             "monitor_by": monitor_by,
             "manage_by": manage_by,
         }
+        # Remove None / empty list items from the temp_body
+        body = {k: v for k, v in body.items() if v}
         return self.post(path, body)
 
     def status(self, action_id: str) -> GlobusHTTPResponse:
@@ -150,7 +152,9 @@ def create_action_client(
         # but create a client anyways in case this action provider is publicly
         # visible without authentication.
         temp_client = ActionClient(
-            "temp_client", base_url=action_url, app_name="tmp_client",
+            "temp_client",
+            base_url=action_url,
+            app_name="tmp_client",
         )
         action_scope = temp_client.action_scope
 

--- a/globus_automate_client/action_client.py
+++ b/globus_automate_client/action_client.py
@@ -84,8 +84,8 @@ class ActionClient(BaseClient):
             "monitor_by": monitor_by,
             "manage_by": manage_by,
         }
-        # Remove None / empty list items from the temp_body
-        body = {k: v for k, v in body.items() if v}
+        # Remove None items from the temp_body
+        body = {k: v for k, v in body.items() if v is not None}
         return self.post(path, body)
 
     def status(self, action_id: str) -> GlobusHTTPResponse:
@@ -152,9 +152,7 @@ def create_action_client(
         # but create a client anyways in case this action provider is publicly
         # visible without authentication.
         temp_client = ActionClient(
-            "temp_client",
-            base_url=action_url,
-            app_name="tmp_client",
+            "temp_client", base_url=action_url, app_name="tmp_client",
         )
         action_scope = temp_client.action_scope
 

--- a/globus_automate_client/cli/actions.py
+++ b/globus_automate_client/cli/actions.py
@@ -65,7 +65,8 @@ def action_run(
         callback=json_validator_callback,
     ),
     request_id: str = typer.Option(
-        None, help=("An identifier to associate with this Action invocation request"),
+        None,
+        help=("An identifier to associate with this Action invocation request"),
     ),
     manage_by: List[str] = typer.Option(
         None,


### PR DESCRIPTION
jgaff reported that when using the SDK's `ActionClient` against the [now old] Datacite AP, he would get errors back indicating that  `monitor_by` and `manage_by` cannot be None. What happened is that the SDK would use `None` for `monitor_by` and `manage_by` if no value was supplied, which resulted in action-run requests being sent with those fields set to `None`.  At the AP, these action-run requests would be rejected bc the `ActionRequest` schema expects `monitor_by` and `manage_by` to be lists if they're set.

The fix is to simply remove False'y values from the action-run body before it get's sent to an AP. Because `monitor_by` and `manage_by` are optional, this will allow users to use the SDK's `ActionClient` without specifying values for those args. 