### PR TITLE
Change schema for the Pass State

### DIFF
--- a/globus_automate_client/flows_schema.json
+++ b/globus_automate_client/flows_schema.json
@@ -154,6 +154,16 @@
         }
       }
     },
+    "ParametersOrInputPathNotRequired": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Parameters"
+        },
+        {
+          "$ref": "#/definitions/InputPath"
+        }
+      ]
+    },
     "ParametersOrInputPath": {
       "oneOf": [
         {
@@ -197,7 +207,7 @@
           "$ref": "#/definitions/NextOrEnd"
         },
         {
-          "$ref": "#/definitions/ParametersOrInputPath"
+          "$ref": "#/definitions/ParametersOrInputPathNotRequired"
         },
         {
           "$ref": "#/definitions/ResultPath"


### PR DESCRIPTION
Make Parameters or InputPath ok, but also allow for neither by
using a slightly new version of the existing Parameters or InputPath
definition that does not include any `required` values.

[ch3823]