### PR TITLE
Adds support for deleting-messages that have been processed

### DIFF
--- a/globus_automate_client/cli/queues.py
+++ b/globus_automate_client/cli/queues.py
@@ -162,7 +162,7 @@ def queue_delete(
     format_and_echo(queue, verbose=verbose)
 
 
-@app.command("receive")
+@app.command("message-receive")
 def queue_receive(
     queue_id: str = typer.Argument(...),
     max_messages: int = typer.Option(
@@ -179,7 +179,7 @@ def queue_receive(
     format_and_echo(queue, verbose=verbose)
 
 
-@app.command("send")
+@app.command("message-send")
 def queue_send(
     queue_id: str = typer.Argument(...),
     message: str = typer.Option(
@@ -201,7 +201,7 @@ def queue_send(
     format_and_echo(message_send, verbose=verbose)
 
 
-@app.command("delete-message")
+@app.command("message-delete")
 def queue_delete_message(
     queue_id: str = typer.Argument(...),
     receipt_handle: List[str] = typer.Option(

--- a/globus_automate_client/queues_client.py
+++ b/globus_automate_client/queues_client.py
@@ -43,7 +43,7 @@ class QueuesClient(BaseClient):
         admins: List[str],
         senders: List[str],
         receivers: List[str],
-        delivery_timeout: int = 86400,
+        delivery_timeout: int = 60,
         **kwargs,
     ) -> GlobusHTTPResponse:
         self.authorizer = get_authorizer_for_scope(QUEUES_ADMIN_SCOPE)
@@ -129,6 +129,17 @@ class QueuesClient(BaseClient):
         if receive_request_attempt_id is not None:
             params["receive_request_attempt_id"] = receive_request_attempt_id
         return self.get(f"/queues/{queue_id}/messages", params=params)
+
+    def delete_messages(
+        self, queue_id: str, receipt_handles: List[str]
+    ) -> GlobusHTTPResponse:
+        self.authorizer = get_authorizer_for_scope(QUEUES_RECEIVE_SCOPE)
+        body = {"data": [{"receipt_handle": rh} for rh in receipt_handles]}
+        return self._request(
+            "DELETE",
+            f"/queues/{queue_id}/messages",
+            json_body=body,
+        )
 
 
 def create_queues_client(


### PR DESCRIPTION
When using the Queues service, a user needs to acknowledge (aka delete) that a message has been processed before the message is removed. If the message is not deleted, the Queue will place the message back at the head of the Queue where the message will once again be retrieved. At present, the CLI and SDK do not support the deletion action which makes it impossible for users to consume from a Queue to process work. This PR adds functionality at the SDK and CLI level supporting message deletion.

This PR also updates the help string on a Queue's `delivery_timeout` parameter. Essentially, this parameter controls how long the Queue waits for a message-deletion before assuming processing has failed and re-adding the message to the head of the Queue. There's work being done on the Queues service to allow `delivery_timeout` to be set to less than 60 seconds and default to 30.

[ch4008]
