### PR TITLE
Improves docs on manually pre-created authorizers for Clients

### DIFF
--- a/docs/source/code_snippets/create_action_client.py
+++ b/docs/source/code_snippets/create_action_client.py
@@ -1,0 +1,8 @@
+from globus_automate_client import create_action_client
+
+# Create an ActionClient for the HelloWorld Action
+ac = create_action_client("https://actions.globus.org/hello_world")
+
+# Run an Action and check its results
+resp = ac.run({"echo_string": "Hello from SDK"})
+assert resp.data["status"] == "SUCCEEDED"

--- a/docs/source/code_snippets/create_flows_client.py
+++ b/docs/source/code_snippets/create_flows_client.py
@@ -1,0 +1,11 @@
+from globus_automate_client import create_flows_client
+from globus_automate_client.token_management import CLIENT_ID
+
+# Create an authenticated FlowsClient that can run operations against the Flows
+# service
+fc = create_flows_client(CLIENT_ID)
+
+# Get a listing of runnable, deployed flows
+available_flows = fc.list_flows(["runnable_by"])
+for flow in available_flows.data["flows"]:
+    print(flow)

--- a/docs/source/code_snippets/premade_authorizers.py
+++ b/docs/source/code_snippets/premade_authorizers.py
@@ -1,0 +1,58 @@
+import os
+
+from globus_sdk import AccessTokenAuthorizer
+
+from globus_automate_client import FlowsClient
+from globus_automate_client.flows_client import (
+    MANAGE_FLOWS_SCOPE,
+    AllowedAuthorizersType,
+)
+from globus_automate_client.token_management import CLIENT_ID
+
+
+def authorizer_retriever(
+    flow_url: str, flow_scope: str, client_id: str
+) -> AllowedAuthorizersType:
+    """
+    This callback will be called when attempting to interact with a
+    specific Flow. The callback will receive the Flow url, Flow scope, and
+    client_id and can choose to use some, all or none of the kwargs. This is
+    expected to return an Authorizer which can be used to make authenticated
+    calls to the Flow.
+
+    The method used to acquire valid credentials is up to the user. Here, we
+    naively create an Authorizer using the same token everytime.
+    """
+    flow_token = os.environ.get("MY_ACCESS_TOKEN")
+    return AccessTokenAuthorizer(flow_token)
+
+
+# Create an AccessTokenAuthorizer using a token that has consents to the
+# MANAGE_FLOWS_SCOPE. This lets the FlowsClient perform operations against the
+# Flow's service i.e. create flow, update a flow, delete a flow
+flows_service_token = os.environ.get("ANOTHER_OR_THE_SAME_ACCESS_TOKEN")
+flows_service_authorizer = AccessTokenAuthorizer(flows_service_token)
+
+fc = FlowsClient.new_client(
+    client_id=CLIENT_ID,
+    authorizer=flows_service_authorizer,
+    authorizer_callback=authorizer_retriever,
+)
+
+my_flows = fc.list_flows()
+print(my_flows)
+
+running_flow = fc.run_flow(
+    "1e6b4406-ee3d-4bc5-9198-74128e108111", None, {"echo_string": "hey"}
+)
+print(running_flow)
+
+# It's possible to create an Authorizer and pass it as a kwarg to the flow
+# operation. This usage will not attempt to make use of the authorizer_callback:
+running_flow_2 = fc.run_flow(
+    "1e6b4406-ee3d-4bc5-9198-74128e108111",
+    None,
+    {"echo_string": "hey"},
+    authorizer=AccessTokenAuthorizer(...),
+)
+print(running_flow_2)


### PR DESCRIPTION
There have been a few questions about how to use the SDK with pre-existing tokens/Authorizers. This PR contains documentation and examples on how the different ways of doing that with ActionClients and FlowsClients. Once merged, these documents will be automatically displayed on our [readthedocs](https://globus-automate-client.readthedocs.io/en/latest/python_sdk.html) site under the SDK section.