### PR TITLE
process_input should not try to load arguments that are None

### DIFF
--- a/globus_automate_client/cli/helpers.py
+++ b/globus_automate_client/cli/helpers.py
@@ -45,16 +45,16 @@ def display_http_details(response: GlobusHTTPResponse) -> None:
 
 
 def process_input(
-    input_arg: str, input_format: InputFormat, error_explanation: str = ""
+    input_arg: Union[str, None], input_format: InputFormat, error_explanation: str = ""
 ) -> Union[Mapping[str, Any], None]:
     """
     Turn input strings into dicts per input format type (InputFormat)
     """
-    input_dict = None
 
     if input_arg is None:
         return None
 
+    input_dict = None
     if input_format is InputFormat.json:
         try:
             input_dict = json.loads(input_arg)

--- a/globus_automate_client/cli/helpers.py
+++ b/globus_automate_client/cli/helpers.py
@@ -51,6 +51,10 @@ def process_input(
     Turn input strings into dicts per input format type (InputFormat)
     """
     input_dict = None
+
+    if input_arg is None:
+        return None
+
     if input_format is InputFormat.json:
         try:
             input_dict = json.loads(input_arg)


### PR DESCRIPTION
Found a bug I introduced while deploying the secure egress prototype. 