### PR TITLE
Adds exception handling to the CLI layer

### DIFF
--- a/globus_automate_client/cli/actions.py
+++ b/globus_automate_client/cli/actions.py
@@ -4,6 +4,7 @@ from typing import List
 
 import typer
 import yaml
+from globus_sdk import GlobusAPIError
 
 from globus_automate_client.cli.callbacks import (
     input_validator_callback,
@@ -59,10 +60,11 @@ def action_introspect(
     Introspect an Action Provider's schema.
     """
     ac = create_action_client(action_url, action_scope)
-    if ac is not None:
+    try:
         result = ac.introspect()
-        format_and_echo(result, output_format.get_dumper(), verbose=verbose)
-    return None
+    except GlobusAPIError as err:
+        result = err
+    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
 
 
 @app.command("run")
@@ -125,11 +127,12 @@ def action_run(
     Launch an Action.
     """
     ac = create_action_client(action_url, action_scope)
-    if ac:
-        parsed_body = process_input(body, input_format)
+    parsed_body = process_input(body, input_format)
+    try:
         result = ac.run(parsed_body, request_id, manage_by, monitor_by)
-        format_and_echo(result, output_format.get_dumper(), verbose=verbose)
-    return None
+    except GlobusAPIError as err:
+        result = err
+    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
 
 
 @app.command("status")
@@ -160,10 +163,11 @@ def action_status(
     Query an Action's status by its ACTION_ID.
     """
     ac = create_action_client(action_url, action_scope)
-    if ac:
+    try:
         result = ac.status(action_id)
-        format_and_echo(result, output_format.get_dumper(), verbose=verbose)
-    return None
+    except GlobusAPIError as err:
+        result = err
+    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
 
 
 @app.command("cancel")
@@ -194,10 +198,11 @@ def action_cancel(
     Terminate a running Action by its ACTION_ID.
     """
     ac = create_action_client(action_url, action_scope)
-    if ac:
+    try:
         result = ac.cancel(action_id)
-        format_and_echo(result, output_format.get_dumper(), verbose=verbose)
-    return None
+    except GlobusAPIError as err:
+        result = err
+    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
 
 
 @app.command("release")
@@ -228,10 +233,11 @@ def action_release(
     Remove an Action's execution history by its ACTION_ID.
     """
     ac = create_action_client(action_url, action_scope)
-    if ac:
+    try:
         result = ac.release(action_id)
-        format_and_echo(result, output_format.get_dumper(), verbose=verbose)
-    return None
+    except GlobusAPIError as err:
+        result = err
+    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/globus_automate_client/cli/constants.py
+++ b/globus_automate_client/cli/constants.py
@@ -1,6 +1,15 @@
 import enum
+import json
+
+import yaml
 
 
 class InputFormat(str, enum.Enum):
     json = "json"
     yaml = "yaml"
+
+    def get_dumper(self):
+        if self is self.json:
+            return json.dumps
+        elif self is self.yaml:
+            return yaml.dump

--- a/globus_automate_client/token_management.py
+++ b/globus_automate_client/token_management.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from fair_research_login import ConfigParserTokenStorage, NativeClient
 from fair_research_login.exc import AuthFailure, LocalServerError
-from globus_sdk import AccessTokenAuthorizer
+from globus_sdk import AccessTokenAuthorizer, GlobusAPIError
 from globus_sdk.exc import AuthAPIError
 
 from globus_automate_client.action_client import ActionClient
@@ -51,12 +51,15 @@ def get_cli_authorizer(
     action_url: str,
     action_scope: Optional[str],
     client_id: str = CLIENT_ID,
-):
+) -> Optional[AccessTokenAuthorizer]:
     if action_scope is None:
         # We don't know the scope which makes it impossible to get a token,
         # but create a client anyways in case this Action Provider is publicly
         # visible and we can introspect its scope
-        action_scope = ActionClient.new_client(action_url, None).action_scope
+        try:
+            action_scope = ActionClient.new_client(action_url, None).action_scope
+        except GlobusAPIError:
+            pass
 
     if action_scope:
         authorizer = get_authorizer_for_scope(action_scope, client_id)


### PR DESCRIPTION
- Ignores exceptions thrown when trying to auto-introspect an AP.  The errors will be explicitly thrown when trying to use the created `ActionClient`
- Supports `GlobusAPIErrors` in printing functions
- Request details now print to `stderr` so that tools like `jq` can parse command output when the `verbosity` flag is set