### PR TITLE
Fixes filename too long errors when reading JSON directly from the command line input

### DIFF
--- a/globus_automate_client/cli/actions.py
+++ b/globus_automate_client/cli/actions.py
@@ -4,6 +4,7 @@ from typing import List
 
 import typer
 import yaml
+from globus_sdk import GlobusAPIError
 
 from globus_automate_client.cli.callbacks import (
     input_validator_callback,
@@ -59,10 +60,11 @@ def action_introspect(
     Introspect an Action Provider's schema.
     """
     ac = create_action_client(action_url, action_scope)
-    if ac is not None:
+    try:
         result = ac.introspect()
-        format_and_echo(result, output_format.get_dumper(), verbose=verbose)
-    return None
+    except GlobusAPIError as err:
+        result = err
+    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
 
 
 @app.command("run")
@@ -125,11 +127,12 @@ def action_run(
     Launch an Action.
     """
     ac = create_action_client(action_url, action_scope)
-    if ac:
-        parsed_body = process_input(body, input_format)
+    parsed_body = process_input(body, input_format)
+    try:
         result = ac.run(parsed_body, request_id, manage_by, monitor_by)
-        format_and_echo(result, output_format.get_dumper(), verbose=verbose)
-    return None
+    except GlobusAPIError as err:
+        result = err
+    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
 
 
 @app.command("status")
@@ -160,10 +163,11 @@ def action_status(
     Query an Action's status by its ACTION_ID.
     """
     ac = create_action_client(action_url, action_scope)
-    if ac:
+    try:
         result = ac.status(action_id)
-        format_and_echo(result, output_format.get_dumper(), verbose=verbose)
-    return None
+    except GlobusAPIError as err:
+        result = err
+    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
 
 
 @app.command("cancel")
@@ -194,10 +198,11 @@ def action_cancel(
     Terminate a running Action by its ACTION_ID.
     """
     ac = create_action_client(action_url, action_scope)
-    if ac:
+    try:
         result = ac.cancel(action_id)
-        format_and_echo(result, output_format.get_dumper(), verbose=verbose)
-    return None
+    except GlobusAPIError as err:
+        result = err
+    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
 
 
 @app.command("release")
@@ -228,10 +233,11 @@ def action_release(
     Remove an Action's execution history by its ACTION_ID.
     """
     ac = create_action_client(action_url, action_scope)
-    if ac:
+    try:
         result = ac.release(action_id)
-        format_and_echo(result, output_format.get_dumper(), verbose=verbose)
-    return None
+    except GlobusAPIError as err:
+        result = err
+    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/globus_automate_client/cli/actions.py
+++ b/globus_automate_client/cli/actions.py
@@ -7,7 +7,7 @@ import yaml
 from globus_sdk import GlobusAPIError
 
 from globus_automate_client.cli.callbacks import (
-    input_validator_callback,
+    input_validator,
     principal_validator,
     url_validator_callback,
 )
@@ -89,7 +89,7 @@ def action_run(
             "JSON string."
         ),
         prompt=True,
-        callback=input_validator_callback,
+        callback=input_validator,
     ),
     request_id: str = typer.Option(
         None,

--- a/globus_automate_client/cli/constants.py
+++ b/globus_automate_client/cli/constants.py
@@ -1,6 +1,15 @@
 import enum
+import json
+
+import yaml
 
 
 class InputFormat(str, enum.Enum):
     json = "json"
     yaml = "yaml"
+
+    def get_dumper(self):
+        if self is self.json:
+            return json.dumps
+        elif self is self.yaml:
+            return yaml.dump

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -9,7 +9,7 @@ from globus_sdk import GlobusAPIError, GlobusHTTPResponse
 from globus_automate_client.cli.callbacks import (
     flow_input_validator,
     flows_endpoint_envvar_callback,
-    input_validator_callback,
+    input_validator,
     principal_or_all_authenticated_users_validator,
     principal_or_public_validator,
     principal_validator,
@@ -103,7 +103,7 @@ def flow_deploy(
             "or a raw string representing a JSON object or YAML definition."
         ),
         prompt=True,
-        callback=input_validator_callback,
+        callback=input_validator,
     ),
     subtitle: str = typer.Option(
         None,
@@ -120,7 +120,7 @@ def flow_deploy(
             "If not provided, no validation will be performed on Flow input. "
             "May be provided as a filename or a raw string."
         ),
-        callback=input_validator_callback,
+        callback=input_validator,
     ),
     keywords: List[str] = typer.Option(
         None,
@@ -206,7 +206,7 @@ def flow_update(
             "JSON or YAML representation of the Flow to update. May be provided as a filename "
             "or a raw string."
         ),
-        callback=input_validator_callback,
+        callback=input_validator,
     ),
     subtitle: str = typer.Option(
         None,
@@ -223,7 +223,7 @@ def flow_update(
             "If not provided, no validation will be performed on Flow input. "
             "May be provided as a filename or a raw string."
         ),
-        callback=input_validator_callback,
+        callback=input_validator,
     ),
     keywords: List[str] = typer.Option(
         None,
@@ -311,7 +311,7 @@ def flow_lint(
             "or a raw string."
         ),
         prompt=True,
-        callback=input_validator_callback,
+        callback=input_validator,
     ),
     validate: bool = typer.Option(
         True,

--- a/globus_automate_client/cli/queues.py
+++ b/globus_automate_client/cli/queues.py
@@ -3,10 +3,7 @@ from typing import List
 
 import typer
 
-from globus_automate_client.cli.callbacks import (
-    principal_validator,
-    text_validator_callback,
-)
+from globus_automate_client.cli.callbacks import input_validator, principal_validator
 from globus_automate_client.cli.helpers import format_and_echo, verbosity_option
 from globus_automate_client.queues_client import create_queues_client
 from globus_automate_client.token_management import CLIENT_ID
@@ -186,9 +183,9 @@ def queue_send(
         ...,
         "--message",
         "-m",
-        help="Text of the message to send. Files may be referenced by prefixing the '@' character to the value.",
+        help="Text of the message to send. Files may also be referenced.",
         prompt=True,
-        callback=text_validator_callback,
+        callback=input_validator,
     ),
     verbose: bool = verbosity_option,
 ):

--- a/globus_automate_client/token_management.py
+++ b/globus_automate_client/token_management.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from fair_research_login import ConfigParserTokenStorage, NativeClient
 from fair_research_login.exc import AuthFailure, LocalServerError
-from globus_sdk import AccessTokenAuthorizer
+from globus_sdk import AccessTokenAuthorizer, GlobusAPIError
 from globus_sdk.exc import AuthAPIError
 
 from globus_automate_client.action_client import ActionClient
@@ -51,12 +51,15 @@ def get_cli_authorizer(
     action_url: str,
     action_scope: Optional[str],
     client_id: str = CLIENT_ID,
-):
+) -> Optional[AccessTokenAuthorizer]:
     if action_scope is None:
         # We don't know the scope which makes it impossible to get a token,
         # but create a client anyways in case this Action Provider is publicly
         # visible and we can introspect its scope
-        action_scope = ActionClient.new_client(action_url, None).action_scope
+        try:
+            action_scope = ActionClient.new_client(action_url, None).action_scope
+        except GlobusAPIError:
+            pass
 
     if action_scope:
         authorizer = get_authorizer_for_scope(action_scope, client_id)


### PR DESCRIPTION
When reading input from the user, the CLI determines if the input is a file _first_ by doing filesystem checks. If it is a valid file, we load the file's contents; if it is not a valid file, we use the input as the content directly. When providing JSON directly on the command line, it is very easy to create a long-enough JSON string that triggers a filename too long error. This PR essentially loads the input as content whenever a filename too long error occurs.

This PR builds off the [Adds exception handling to the CLI layer](https://github.com/globus/globus-automate-client/pull/38) PR