### PR TITLE
Remove ActionScope from example flows

### DIFF
--- a/examples/flows/complex-hello-world/definition.json
+++ b/examples/flows/complex-hello-world/definition.json
@@ -1,61 +1,59 @@
 {
-    "Comment": "Run Hello World in a loop over the input list Hellos",
-    "StartAt": "RunHelloWorld",
-    "States": {
-        "RunHelloWorld": {
-            "Comment": "Run The Hello World Action Async with values from Hellos list",
-            "Type": "Action",
-            "ActionUrl": "https://actions.automate.globus.org/hello_world",
-            "ActionScope": "https://auth.globus.org/scopes/actions.globus.org/hello_world",
-            "Parameters": {
-                "echo_string.$": "$.input.Hellos[0]",
-                "sleep_time": 3
-            },
-            "ResultPath": "$.HelloOutput",
-            "Next": "SliceHellos"
+  "Comment": "Run Hello World in a loop over the input list Hellos",
+  "StartAt": "RunHelloWorld",
+  "States": {
+    "RunHelloWorld": {
+      "Comment": "Run The Hello World Action Async with values from Hellos list",
+      "Type": "Action",
+      "ActionUrl": "https://actions.automate.globus.org/hello_world",
+      "Parameters": {
+        "echo_string.$": "$.input.Hellos[0]",
+        "sleep_time": 3
+      },
+      "ResultPath": "$.HelloOutput",
+      "Next": "SliceHellos"
+    },
+    "SliceHellos": {
+      "Comment": "Remove the first element from the Hellos list",
+      "Type": "Pass",
+      "Parameters": {
+        "Hellos.$": "$.input.Hellos[1:]"
+      },
+      "ResultPath": "$.input",
+      "Next": "ComputeCompletion"
+    },
+    "ComputeCompletion": {
+      "Comment": "Evaluate an expression to determine if there's more work to do",
+      "Type": "Action",
+      "ActionUrl": "https://actions.globus.org/expression_eval",
+      "Parameters": {
+        "arguments": {
+          "Hellos.$": "$.input.Hellos"
         },
-        "SliceHellos": {
-            "Comment": "Remove the first element from the Hellos list",
-            "Type": "Pass",
-            "Parameters": {
-                "Hellos.$": "$.input.Hellos[1:]"
-            },
-            "ResultPath": "$.input",
-            "Next": "ComputeCompletion"
-        },
-        "ComputeCompletion": {
-            "Comment": "Evaluate an expression to determine if there's more work to do",
-            "Type": "Action",
-            "ActionUrl": "https://actions.globus.org/expression_eval",
-            "ActionScope": "https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/expression",
-            "Parameters": {
-                "arguments": {
-                    "Hellos.$": "$.input.Hellos"
-                },
-                "expression": "Hellos == Hellos[0:0]",
-                "result_path": "loop_done"
-            },
-            "ResultPath": "$.ComputeCompletionOut",
-            "Next": "CheckCompletion"
-        },
-        "CheckCompletion": {
-            "Type": "Choice",
-            "Default": "Done",
-            "Choices": [
-                {
-                    "Variable": "$.ComputeCompletionOut.details.loop_done",
-                    "BooleanEquals": false,
-                    "Next": "RunHelloWorld"
-                }
-            ]
-        },
-        "Done": {
-            "Type": "Pass",
-            "Parameters": {
-                "Completed": "Successfully"
-            },
-            "ResultPath": "$.FinalPass",
-            "End": true
+        "expression": "Hellos == Hellos[0:0]",
+        "result_path": "loop_done"
+      },
+      "ResultPath": "$.ComputeCompletionOut",
+      "Next": "CheckCompletion"
+    },
+    "CheckCompletion": {
+      "Type": "Choice",
+      "Default": "Done",
+      "Choices": [
+        {
+          "Variable": "$.ComputeCompletionOut.details.loop_done",
+          "BooleanEquals": false,
+          "Next": "RunHelloWorld"
         }
+      ]
+    },
+    "Done": {
+      "Type": "Pass",
+      "Parameters": {
+        "Completed": "Successfully"
+      },
+      "ResultPath": "$.FinalPass",
+      "End": true
     }
+  }
 }

--- a/examples/flows/hello-plus-transfer/definition.json
+++ b/examples/flows/hello-plus-transfer/definition.json
@@ -1,33 +1,31 @@
 {
-    "StartAt": "HelloState",
-    "States": {
-        "HelloState": {
-            "ActionUrl": "https://actions.automate.globus.org/hello_world",
-            "ActionScope": "https://auth.globus.org/scopes/actions.globus.org/hello_world",
-            "Parameters": {
-                "echo_string.$": "$.HelloInput.echo_string"
-            },
-            "Next": "TransferState",
-            "ResultPath": "$.HelloOutput",
-            "Type": "Action"
-        },
-        "TransferState": {
-            "ActionUrl": "https://actions.automate.globus.org/transfer/transfer",
-            "ActionScope": "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer",
-            "Parameters": {
-                "source_endpoint_id.$": "$.TransferInput.source_endpoint_id",
-                "destination_endpoint_id.$": "$.TransferInput.destination_endpoint_id",
-                "transfer_items": [
-                    {
-                        "source_path.$": "$.TransferInput.source_path",
-                        "destination_path.$": "$.TransferInput.destination_path",
-                        "recursive.$": "$.TransferInput.recursive"
-                    }
-                ]
-            },
-            "ResultPath": "$.TransferOutput",
-            "Type": "Action",
-            "End": true
-        }
+  "StartAt": "HelloState",
+  "States": {
+    "HelloState": {
+      "ActionUrl": "https://actions.automate.globus.org/hello_world",
+      "Parameters": {
+        "echo_string.$": "$.HelloInput.echo_string"
+      },
+      "Next": "TransferState",
+      "ResultPath": "$.HelloOutput",
+      "Type": "Action"
+    },
+    "TransferState": {
+      "ActionUrl": "https://actions.automate.globus.org/transfer/transfer",
+      "Parameters": {
+        "source_endpoint_id.$": "$.TransferInput.source_endpoint_id",
+        "destination_endpoint_id.$": "$.TransferInput.destination_endpoint_id",
+        "transfer_items": [
+          {
+            "source_path.$": "$.TransferInput.source_path",
+            "destination_path.$": "$.TransferInput.destination_path",
+            "recursive.$": "$.TransferInput.recursive"
+          }
+        ]
+      },
+      "ResultPath": "$.TransferOutput",
+      "Type": "Action",
+      "End": true
     }
+  }
 }

--- a/examples/flows/hello-world-run-as/definition.json
+++ b/examples/flows/hello-world-run-as/definition.json
@@ -1,18 +1,17 @@
 {
-    "Comment": "Run the Hello World Action with an identity",
-    "StartAt": "RunHelloWorld",
-    "States": {
-        "RunHelloWorld": {
-            "Comment": "Say Hello World",
-            "Type": "Action",
-            "ActionUrl": "https://actions.automate.globus.org/hello_world",
-            "ActionScope": "https://auth.globus.org/scopes/actions.globus.org/hello_world",
-            "RunAs": "pruyne",
-            "Parameters": {
-                "echo_string": "Run As Pruyne"
-            },
-            "ResultPath": "$.HelloResult",
-            "End": true
-        }
+  "Comment": "Run the Hello World Action with an identity",
+  "StartAt": "RunHelloWorld",
+  "States": {
+    "RunHelloWorld": {
+      "Comment": "Say Hello World",
+      "Type": "Action",
+      "ActionUrl": "https://actions.automate.globus.org/hello_world",
+      "RunAs": "pruyne",
+      "Parameters": {
+        "echo_string": "Run As Pruyne"
+      },
+      "ResultPath": "$.HelloResult",
+      "End": true
     }
+  }
 }

--- a/examples/flows/hello-world-yaml/definition.yaml
+++ b/examples/flows/hello-world-yaml/definition.yaml
@@ -6,7 +6,6 @@ States:
     Comment: Say Hello World
     Type: Action
     ActionUrl: 'https://actions.automate.globus.org/hello_world'
-    ActionScope: 'https://auth.globus.org/scopes/actions.globus.org/hello_world'
     Parameters:
       echo_string.$: $.input.echo_string
       sleep_time.$: $.input.sleep

--- a/examples/flows/hello-world/definition.json
+++ b/examples/flows/hello-world/definition.json
@@ -1,19 +1,18 @@
 {
-    "Comment": "Run the Hello World Action as the Flow's identity",
-    "StartAt": "RunHelloWorld",
-    "States": {
-        "RunHelloWorld": {
-            "RunAs": "Flow",
-            "Comment": "Say Hello World",
-            "Type": "Action",
-            "ActionUrl": "https://actions.automate.globus.org/hello_world",
-            "ActionScope": "https://auth.globus.org/scopes/actions.globus.org/hello_world",
-            "Parameters": {
-                "echo_string.$": "$.input.echo_string",
-                "sleep_time.$": "$.input.sleep"
-            },
-            "ResultPath": "$.HelloResult",
-            "End": true
-        }
+  "Comment": "Run the Hello World Action as the Flow's identity",
+  "StartAt": "RunHelloWorld",
+  "States": {
+    "RunHelloWorld": {
+      "RunAs": "Flow",
+      "Comment": "Say Hello World",
+      "Type": "Action",
+      "ActionUrl": "https://actions.automate.globus.org/hello_world",
+      "Parameters": {
+        "echo_string.$": "$.input.echo_string",
+        "sleep_time.$": "$.input.sleep"
+      },
+      "ResultPath": "$.HelloResult",
+      "End": true
     }
+  }
 }

--- a/examples/flows/multi-transfer/definition.json
+++ b/examples/flows/multi-transfer/definition.json
@@ -1,44 +1,42 @@
 {
-    "Comment": "Two step transfer",
-    "StartAt": "Transfer1",
-    "States": {
-        "Transfer1": {
-            "Comment": "Initial Transfer from Campus to DMZ",
-            "Type": "Action",
-            "ActionUrl": "https://actions.globus.org/transfer/transfer",
-            "ActionScope": "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer",
-            "Parameters": {
-                "source_endpoint_id.$": "$.source_endpoint_id",
-                "destination_endpoint_id.$": "$.staging_endpoint_id",
-                "transfer_items": [
-                    {
-                        "source_path.$": "$.source_path",
-                        "destination_path.$": "$.staging_path",
-                        "recursive": true
-                    }
-                ]
-            },
-            "ResultPath": "$.Transfer1Result",
-            "Next": "Transfer2"
-        },
-        "Transfer2": {
-            "Comment": "Transfer from DMZ to dataset repository",
-            "Type": "Action",
-            "ActionUrl": "https://actions.globus.org/transfer/transfer",
-            "ActionScope": "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer",
-            "Parameters": {
-                "source_endpoint_id.$": "$.staging_endpoint_id",
-                "destination_endpoint_id.$": "$.destination_endpoint_id",
-                "transfer_items": [
-                    {
-                        "source_path.$": "$.staging_path",
-                        "destination_path.$": "$.destination_path",
-                        "recursive": true
-                    }
-                ]
-            },
-            "ResultPath": "$.Transfer2Result",
-            "End": true
-        }
+  "Comment": "Two step transfer",
+  "StartAt": "Transfer1",
+  "States": {
+    "Transfer1": {
+      "Comment": "Initial Transfer from Campus to DMZ",
+      "Type": "Action",
+      "ActionUrl": "https://actions.globus.org/transfer/transfer",
+      "Parameters": {
+        "source_endpoint_id.$": "$.source_endpoint_id",
+        "destination_endpoint_id.$": "$.staging_endpoint_id",
+        "transfer_items": [
+          {
+            "source_path.$": "$.source_path",
+            "destination_path.$": "$.staging_path",
+            "recursive": true
+          }
+        ]
+      },
+      "ResultPath": "$.Transfer1Result",
+      "Next": "Transfer2"
+    },
+    "Transfer2": {
+      "Comment": "Transfer from DMZ to dataset repository",
+      "Type": "Action",
+      "ActionUrl": "https://actions.globus.org/transfer/transfer",
+      "Parameters": {
+        "source_endpoint_id.$": "$.staging_endpoint_id",
+        "destination_endpoint_id.$": "$.destination_endpoint_id",
+        "transfer_items": [
+          {
+            "source_path.$": "$.staging_path",
+            "destination_path.$": "$.destination_path",
+            "recursive": true
+          }
+        ]
+      },
+      "ResultPath": "$.Transfer2Result",
+      "End": true
     }
+  }
 }

--- a/examples/flows/notify-of-options-and-report/definition.json
+++ b/examples/flows/notify-of-options-and-report/definition.json
@@ -1,62 +1,59 @@
 {
-    "Comment": "Use the notification service to notify of a choice and then report the result",
-    "StartAt": "NotifyOfOption",
-    "States": {
-        "NotifyOfOption": {
-            "Type": "Action",
-            "ActionUrl": "https://actions.automate.globus.org/notification/notify",
-            "ActionScope": "https://auth.globus.org/scopes/helloworld.actions.automate.globus.org/notification_notify",
-            "Parameters": {
-                "notification_method": "email",
-                "sender": "globus.automate.notifications@gmail.com",
-                "destination.$": "$.notification_recipient",
-                "subject.$": "$.notification_subject",
-                "body_template.$": "$.notification_body_template",
-                "body_variables.$": "$.notification_body_variables",
-                "body_mimetype": "text/html",
-                "send_credentials.$": "$.server_credentials"
-            },
-            "ResultPath": "$.EmailNotificationResult",
-            "Next": "CreateOption"
-        },
-        "CreateOption": {
-            "Type": "Action",
-            "ActionUrl": "https://actions.automate.globus.org/weboption/wait_for_option",
-            "ActionScope": "https://auth.globus.org/scopes/helloworld.actions.automate.globus.org/weboption_wait_for_option",
-            "Parameters": {
-                "options": [
-                    {
-                        "name": "Accept",
-                        "url_suffix.$": "$.notification_body_variables.accept_option_suffix",
-                        "completed_message": "Thank you for choosing to Accept"
-                    },
-                    {
-                        "name": "Reject",
-                        "url_suffix.$": "$.notification_body_variables.reject_option_suffix",
-                        "completed_message": "We're sorry you had to Reject"
-                    }
-                ]
-            },
-            "ResultPath": "$.OptionResult",
-            "WaitTime": 7200,
-            "Next": "NotifyOfResult"
-        },
-        "NotifyOfResult": {
-            "Type": "Action",
-            "ActionUrl": "https://actions.automate.globus.org/notification/notify",
-            "ActionScope": "https://auth.globus.org/scopes/helloworld.actions.automate.globus.org/notification_notify",
-            "Parameters": {
-                "notification_method": "email",
-                "sender": "globus.automate.notifications@gmail.com",
-                "destination.$": "$.notification_recipient",
-                "subject.$": "$.result_subject",
-                "body_template.$": "$.result_body_template",
-                "body_variables.$": "$.OptionResult.details",
-                "body_mimetype": "text/html",
-                "send_credentials.$": "$.server_credentials"
-            },
-            "ResultPath": "$.EmailOptionResultResult",
-            "End": true
-        }
+  "Comment": "Use the notification service to notify of a choice and then report the result",
+  "StartAt": "NotifyOfOption",
+  "States": {
+    "NotifyOfOption": {
+      "Type": "Action",
+      "ActionUrl": "https://actions.automate.globus.org/notification/notify",
+      "Parameters": {
+        "notification_method": "email",
+        "sender": "globus.automate.notifications@gmail.com",
+        "destination.$": "$.notification_recipient",
+        "subject.$": "$.notification_subject",
+        "body_template.$": "$.notification_body_template",
+        "body_variables.$": "$.notification_body_variables",
+        "body_mimetype": "text/html",
+        "send_credentials.$": "$.server_credentials"
+      },
+      "ResultPath": "$.EmailNotificationResult",
+      "Next": "CreateOption"
+    },
+    "CreateOption": {
+      "Type": "Action",
+      "ActionUrl": "https://actions.automate.globus.org/weboption/wait_for_option",
+      "Parameters": {
+        "options": [
+          {
+            "name": "Accept",
+            "url_suffix.$": "$.notification_body_variables.accept_option_suffix",
+            "completed_message": "Thank you for choosing to Accept"
+          },
+          {
+            "name": "Reject",
+            "url_suffix.$": "$.notification_body_variables.reject_option_suffix",
+            "completed_message": "We're sorry you had to Reject"
+          }
+        ]
+      },
+      "ResultPath": "$.OptionResult",
+      "WaitTime": 7200,
+      "Next": "NotifyOfResult"
+    },
+    "NotifyOfResult": {
+      "Type": "Action",
+      "ActionUrl": "https://actions.automate.globus.org/notification/notify",
+      "Parameters": {
+        "notification_method": "email",
+        "sender": "globus.automate.notifications@gmail.com",
+        "destination.$": "$.notification_recipient",
+        "subject.$": "$.result_subject",
+        "body_template.$": "$.result_body_template",
+        "body_variables.$": "$.OptionResult.details",
+        "body_mimetype": "text/html",
+        "send_credentials.$": "$.server_credentials"
+      },
+      "ResultPath": "$.EmailOptionResultResult",
+      "End": true
     }
+  }
 }

--- a/examples/flows/send-notification/definition.json
+++ b/examples/flows/send-notification/definition.json
@@ -1,33 +1,32 @@
 {
-    "Comment": "Use the Notification Action to send an Email",
-    "StartAt": "EmailNotificationAction",
-    "States": {
-        "EmailNotificationAction": {
-            "Type": "Action",
-            "ActionUrl": "https://actions.automate.globus.org/notification/notify",
-            "ActionScope": "https://auth.globus.org/scopes/helloworld.actions.automate.globus.org/notification_notify",
-            "Parameters": {
-                "notification_method": "email",
-                "sender": "globus.automate.notifications@gmail.com",
-                "destination.$": "$.EmailNotificationInput.destination",
-                "subject.$": "$.EmailNotificationInput.subject",
-                "body_template.$": "$.EmailNotificationInput.body_template",
-                "body_variables.$": "$.EmailNotificationInput.body_variables",
-                "body_mimetype": "text/html",
-                "send_credentials": [
-                    {
-                        "credential_type": "smtp",
-                        "credential_method": "email",
-                        "credential_value": {
-                            "hostname": "smtp.gmail.com",
-                            "username": "globus.automate.notifications@gmail.com",
-                            "password": "password"
-                        }
-                    }
-                ]
-            },
-            "ResultPath": "$.EmailNotificationResult",
-            "End": true
-        }
+  "Comment": "Use the Notification Action to send an Email",
+  "StartAt": "EmailNotificationAction",
+  "States": {
+    "EmailNotificationAction": {
+      "Type": "Action",
+      "ActionUrl": "https://actions.automate.globus.org/notification/notify",
+      "Parameters": {
+        "notification_method": "email",
+        "sender": "globus.automate.notifications@gmail.com",
+        "destination.$": "$.EmailNotificationInput.destination",
+        "subject.$": "$.EmailNotificationInput.subject",
+        "body_template.$": "$.EmailNotificationInput.body_template",
+        "body_variables.$": "$.EmailNotificationInput.body_variables",
+        "body_mimetype": "text/html",
+        "send_credentials": [
+          {
+            "credential_type": "smtp",
+            "credential_method": "email",
+            "credential_value": {
+              "hostname": "smtp.gmail.com",
+              "username": "globus.automate.notifications@gmail.com",
+              "password": "password"
+            }
+          }
+        ]
+      },
+      "ResultPath": "$.EmailNotificationResult",
+      "End": true
     }
+  }
 }

--- a/examples/flows/single-delete/definition.json
+++ b/examples/flows/single-delete/definition.json
@@ -1,20 +1,19 @@
 {
-    "Comment": "Run a single delete operation via Transfer Deployed with id ade380b8-f423-42dd-ab88-e47315e373bc",
-    "StartAt": "DoDelete",
-    "States": {
-        "DoDelete": {
-            "Comment": "Perform Delete",
-            "Type": "Action",
-            "ActionUrl": "https://actions.automate.globus.org/transfer/delete",
-            "ActionScope": "https://auth.globus.org/scopes/actions.globus.org/transfer/delete",
-            "Parameters": {
-                "endpoint_id.$": "$.endpoint_id",
-                "recursive.$": "$.recursive",
-                "label.$": "$.label",
-                "items.$": "$.items"
-            },
-            "ResultPath": "$.DeleteResult",
-            "End": true
-        }
+  "Comment": "Run a single delete operation via Transfer Deployed with id ade380b8-f423-42dd-ab88-e47315e373bc",
+  "StartAt": "DoDelete",
+  "States": {
+    "DoDelete": {
+      "Comment": "Perform Delete",
+      "Type": "Action",
+      "ActionUrl": "https://actions.automate.globus.org/transfer/delete",
+      "Parameters": {
+        "endpoint_id.$": "$.endpoint_id",
+        "recursive.$": "$.recursive",
+        "label.$": "$.label",
+        "items.$": "$.items"
+      },
+      "ResultPath": "$.DeleteResult",
+      "End": true
     }
+  }
 }

--- a/examples/flows/single-transfer/definition.json
+++ b/examples/flows/single-transfer/definition.json
@@ -1,19 +1,18 @@
 {
-    "Comment": "Run a single transfer from the source endpoint, to the destination endpoint",
-    "StartAt": "RunTransfer",
-    "States": {
-        "RunTransfer": {
-            "Comment": "Start the Transfer",
-            "Type": "Action",
-            "ActionUrl": "https://actions.automate.globus.org/transfer/transfer",
-            "ActionScope": "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer",
-            "Parameters": {
-                "source_endpoint_id.$": "$.source_endpoint_id",
-                "destination_endpoint_id.$": "$.destination_endpoint_id",
-                "transfer_items.$": "$.transfer_items"
-            },
-            "ResultPath": "$.TransferResult",
-            "End": true
-        }
+  "Comment": "Run a single transfer from the source endpoint, to the destination endpoint",
+  "StartAt": "RunTransfer",
+  "States": {
+    "RunTransfer": {
+      "Comment": "Start the Transfer",
+      "Type": "Action",
+      "ActionUrl": "https://actions.automate.globus.org/transfer/transfer",
+      "Parameters": {
+        "source_endpoint_id.$": "$.source_endpoint_id",
+        "destination_endpoint_id.$": "$.destination_endpoint_id",
+        "transfer_items.$": "$.transfer_items"
+      },
+      "ResultPath": "$.TransferResult",
+      "End": true
     }
+  }
 }

--- a/examples/flows/web-option-with-parameters/definition.json
+++ b/examples/flows/web-option-with-parameters/definition.json
@@ -1,42 +1,41 @@
 {
-    "Comment": "Use the Web Option Action to wait for a URL to be selected",
-    "StartAt": "WebOptionAction",
-    "States": {
-        "WebOptionAction": {
-            "Type": "Action",
-            "ActionUrl": "https://actions.automate.globus.org/weboption/wait_for_option",
-            "ActionScope": "https://auth.globus.org/scopes/helloworld.actions.automate.globus.org/weboption_wait_for_option",
-            "Parameters": {
-                "landing_page": {
-                    "url_suffix": "jcp_landing_page",
-                    "header_background": "darkred",
-                    "header_icon_link": "http://example.com",
-                    "header_text": "Hey, Make a choice",
-                    "page_title": "Look at my title",
-                    "preamble_text": "Please make a very careful decision"
-                },
-                "options": [
-                    {
-                        "name": "b",
-                        "description": "This is option b",
-                        "url_suffix": "jcp_option_b_new",
-                        "include_body": true,
-                        "include_query_params": true,
-                        "completed_message": "Thank you for selecting 'b'"
-                    },
-                    {
-                        "name": "default",
-                        "description": "This is the default option",
-                        "url_suffix": "jcp_option_a_new",
-                        "include_body": true,
-                        "include_query_params": true,
-                        "completed_message": "Thank you for selecting the default option"
-                    }
-                ]
-            },
-            "ResultPath": "$.WebOptionResult",
-            "WaitTime": 7200,
-            "End": true
-        }
+  "Comment": "Use the Web Option Action to wait for a URL to be selected",
+  "StartAt": "WebOptionAction",
+  "States": {
+    "WebOptionAction": {
+      "Type": "Action",
+      "ActionUrl": "https://actions.automate.globus.org/weboption/wait_for_option",
+      "Parameters": {
+        "landing_page": {
+          "url_suffix": "jcp_landing_page",
+          "header_background": "darkred",
+          "header_icon_link": "http://example.com",
+          "header_text": "Hey, Make a choice",
+          "page_title": "Look at my title",
+          "preamble_text": "Please make a very careful decision"
+        },
+        "options": [
+          {
+            "name": "b",
+            "description": "This is option b",
+            "url_suffix": "jcp_option_b_new",
+            "include_body": true,
+            "include_query_params": true,
+            "completed_message": "Thank you for selecting 'b'"
+          },
+          {
+            "name": "default",
+            "description": "This is the default option",
+            "url_suffix": "jcp_option_a_new",
+            "include_body": true,
+            "include_query_params": true,
+            "completed_message": "Thank you for selecting the default option"
+          }
+        ]
+      },
+      "ResultPath": "$.WebOptionResult",
+      "WaitTime": 7200,
+      "End": true
     }
+  }
 }

--- a/examples/flows/web-option/definition.json
+++ b/examples/flows/web-option/definition.json
@@ -1,17 +1,16 @@
 {
-    "Comment": "Use the Web Option Action to wait for a URL to be selected",
-    "StartAt": "WebOptionAction",
-    "States": {
-        "WebOptionAction": {
-            "Type": "Action",
-            "ActionUrl": "https://actions.automate.globus.org/weboption/wait_for_option",
-            "ActionScope": "https://auth.globus.org/scopes/helloworld.actions.automate.globus.org/weboption_wait_for_option",
-            "Parameters": {
-                "options.$": "$.options"
-            },
-            "ResultPath": "$.WebOptionResult",
-            "WaitTime": 7200,
-            "End": true
-        }
+  "Comment": "Use the Web Option Action to wait for a URL to be selected",
+  "StartAt": "WebOptionAction",
+  "States": {
+    "WebOptionAction": {
+      "Type": "Action",
+      "ActionUrl": "https://actions.automate.globus.org/weboption/wait_for_option",
+      "Parameters": {
+        "options.$": "$.options"
+      },
+      "ResultPath": "$.WebOptionResult",
+      "WaitTime": 7200,
+      "End": true
     }
+  }
 }


### PR DESCRIPTION
Including the scope in the flow definition is an anti-pattern at this
point because introspection by the Flows service does a better job.

Also, seems my editor settings have changed since last I visited these
files and indent size has shrunk, likely making for any ugly
diff. Sorry, but I guess since I prefer the 2 space indent it is
better in the long run.
