### PR TITLE
Adds Filtering and Ordering on Flow List and Flow Action List

### DIFF
--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -395,8 +395,8 @@ def flow_list(
         "--filter",
         help="A filtering criteria in the form 'key=value' to apply to the "
         "resulting Flow listing. The key indicates the filter, the value "
-        "indicates the pattern to match. Multiple patterns may for a single key "
-        "may be specified as a comma seperated string, the results for which will "
+        "indicates the pattern to match. Multiple patterns for a single key may "
+        "be specified as a comma seperated string, the results for which will "
         "represent a logical OR. If multiple filters are applied, the returned "
         "data will be the result of a logical AND between them. [repeatable]",
     ),
@@ -616,8 +616,8 @@ def flow_actions_list(
         "--filter",
         help="A filtering criteria in the form 'key=value' to apply to the "
         "resulting Action listing. The key indicates the filter, the value "
-        "indicates the pattern to match. Multiple patterns may for a single key "
-        "may be specified as a comma seperated string, the results for which will "
+        "indicates the pattern to match. Multiple patterns for a single key may "
+        "be specified as a comma seperated string, the results for which will "
         "represent a logical OR. If multiple filters are applied, the returned "
         "data will be the result of a logical AND between them. [repeatable]",
     ),

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -1,7 +1,7 @@
 import functools
 import json
 from enum import Enum
-from typing import Any, List, Mapping
+from typing import Any, List, Mapping, Optional
 
 import typer
 import yaml
@@ -25,6 +25,7 @@ from globus_automate_client.cli.helpers import (
     flow_log_runner,
     format_and_echo,
     get_http_details,
+    parse_query_options,
     process_input,
     request_runner,
     verbosity_option,
@@ -389,6 +390,25 @@ def flow_list(
         hidden=True,
         callback=flows_endpoint_envvar_callback,
     ),
+    filters: Optional[List[str]] = typer.Option(
+        None,
+        "--filter",
+        help="A filtering criteria in the form 'key=value' to apply to the "
+        "resulting Flow listing. The key indicates the filter, the value "
+        "indicates the pattern to match. Multiple patterns may for a single key "
+        "may be specified as a comma seperated string, the results for which will "
+        "represent a logical OR. If multiple filters are applied, the returned "
+        "data will be the result of a logical AND between them. [repeatable]",
+    ),
+    orderings: Optional[List[str]] = typer.Option(
+        None,
+        "--orderby",
+        help="An ordering criteria in the form 'key=value' to apply to the resulting "
+        "Flow listing. The key indicates the field to order on, and the value is "
+        "either ASC, for ascending order, or DESC, for descending order. The first "
+        "ordering criteria will be used to sort the data, subsequent ordering criteria "
+        "will further sort ties. [repeatable]",
+    ),
     verbose: bool = verbosity_option,
     output_format: FlowDisplayFormat = typer.Option(
         FlowDisplayFormat.json,
@@ -402,10 +422,17 @@ def flow_list(
     """
     List Flows for which you have access.
     """
+    parsed_filters = parse_query_options(filters)
+    parsed_orderings = parse_query_options(orderings)
+
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
     try:
         flows = fc.list_flows(
-            roles=[r.value for r in roles], marker=marker, per_page=per_page
+            roles=[r.value for r in roles],
+            marker=marker,
+            per_page=per_page,
+            filters=parsed_filters,
+            orderings=parsed_orderings,
         )
     except GlobusAPIError as err:
         format_and_echo(err, verbose=verbose)

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -611,6 +611,25 @@ def flow_actions_list(
         min=1,
         max=50,
     ),
+    filters: Optional[List[str]] = typer.Option(
+        None,
+        "--filter",
+        help="A filtering criteria in the form 'key=value' to apply to the "
+        "resulting Action listing. The key indicates the filter, the value "
+        "indicates the pattern to match. Multiple patterns may for a single key "
+        "may be specified as a comma seperated string, the results for which will "
+        "represent a logical OR. If multiple filters are applied, the returned "
+        "data will be the result of a logical AND between them. [repeatable]",
+    ),
+    orderings: Optional[List[str]] = typer.Option(
+        None,
+        "--orderby",
+        help="An ordering criteria in the form 'key=value' to apply to the resulting "
+        "Flow listing. The key indicates the field to order on, and the value is "
+        "either ASC, for ascending order, or DESC, for descending order. The first "
+        "ordering criteria will be used to sort the data, subsequent ordering criteria "
+        "will further sort ties. [repeatable]",
+    ),
     flows_endpoint: str = typer.Option(
         PROD_FLOWS_BASE_URL,
         hidden=True,
@@ -621,6 +640,8 @@ def flow_actions_list(
     """
     List a Flow definition's discrete invocations.
     """
+    parsed_filters = parse_query_options(filters)
+    parsed_orderings = parse_query_options(orderings)
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
 
     # This None check and check makes me unhappy but is necessary for mypy to
@@ -640,6 +661,8 @@ def flow_actions_list(
             roles=roles_str,
             marker=marker,
             per_page=per_page,
+            filters=parsed_filters,
+            orderings=parsed_orderings,
         )
     except GlobusAPIError as err:
         result = err

--- a/globus_automate_client/cli/helpers.py
+++ b/globus_automate_client/cli/helpers.py
@@ -1,6 +1,6 @@
 import json
 import time
-from typing import Any, Callable, Mapping, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
 import typer
 import yaml
@@ -197,3 +197,22 @@ def process_input(
             raise typer.BadParameter(f"Invalid YAML{error_explanation}: {e}")
 
     return input_dict
+
+
+def parse_query_options(queries: Optional[List[str]]) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+
+    if queries is None:
+        return result
+
+    for q in queries:
+        try:
+            field, pattern = q.split("=")
+        except ValueError:
+            raise typer.BadParameter(
+                f"Issue parsing '{q}'. Options should be of the form 'field=pattern'."
+            )
+        if pattern == "":
+            raise typer.BadParameter(f"Issue parsing '{q}'. Missing pattern.")
+        result[field] = pattern
+    return result

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -335,6 +335,8 @@ class FlowsClient(BaseClient):
         roles: Optional[List[str]] = None,
         marker: Optional[str] = None,
         per_page: Optional[int] = None,
+        filters: Optional[dict] = None,
+        orderings: Optional[dict] = None,
         **kwargs,
     ) -> GlobusHTTPResponse:
         """
@@ -357,6 +359,18 @@ class FlowsClient(BaseClient):
             service and returned by operations that support pagination.
         :param per_page: The number of results to return per page. If
             supplied a pagination_token, this parameter has no effect.
+        :param filters: A filtering criteria to apply to the resulting Flow
+            listing. The keys indicate the filter, the values indicate the
+            pattern to match. The returned data will be the result of a logical
+            AND between the filters. Patterns may be comma separated to produce
+            the result of a logical OR.
+        :param orderings: An ordering criteria to apply to the resulting
+            Flow listing. The keys indicate the field to order on, and
+            the value can be either ASC, for ascending order, or DESC, for
+            descending order. The first ordering criteria will be used to sort
+            the data, subsequent ordering criteria will be applied for ties.
+            Note: To ensure orderings are applied in the correct order, use an
+            OrderedDict if trying to apply multiple orderings.
         """
         self.authorizer = self.flow_management_authorizer
         params = {}
@@ -366,6 +380,13 @@ class FlowsClient(BaseClient):
             params["pagination_token"] = marker
         if per_page is not None and marker is None:
             params["per_page"] = str(per_page)
+        if filters is not None:
+            params.update(filters)
+        if orderings is not None:
+            builder = []
+            for field, value in orderings.items():
+                builder.append(f"{field} {value}")
+            params["orderby"] = ",".join(builder)
         return self.get("/flows", params=params, **kwargs)
 
     def delete_flow(self, flow_id: str, **kwargs):


### PR DESCRIPTION
Adds support in the CLI and SDK for the new filtering/ordering options available on the Flow List and Flow Action List endpoints and it's corresponding usage documentation. 

In the SDK, the general approach is to accept a series of filters/ordering options as dictionaries which get mapped to query parameters sent off to the Flows service.

In the CLI, I added fairly generic `--filter` and `--orderby` which accept `key=value` formatted strings. I think this is the most generalizable way of supporting adhoc options as they change or get updated on the server. There's still the issue of where a user should look to find which fields support filtering and ordering. I think I'd rather keep that information out of the CLI for now and bank on some Flows documentation providing that information.