### PR TITLE
Adds documentation around monitor_by and manage_by

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VIRTUAL_ENV = .venv
 PYTHON_VERSION ?= python3.6
 POETRY ?= poetry
 
-.PHONY: lock test build clean help lint develop format typecheck lint_all api-docs
+.PHONY: lock test build clean help lint develop format typecheck lint_all api-docs docs
 
 # settings from .pytest.cfg file
 PYTEST_OPTS?=-c .pytest.cfg
@@ -70,3 +70,6 @@ clean:
 	rm -f *.tar.gz
 	rm -rf tar-source
 	rm -rf dist
+
+docs:
+	poetry run make --directory=docs html

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,8 @@ of this package. It is published for ease of distribution among those planning
 to use it for its intended, experimental, purpose.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
+   :titlesonly:
 
    quick_start
    concepts

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -46,7 +46,7 @@ SDK in a Python script:
 
 Use of the CLI and SDK to invoke any services requires authentication. Upon
 first interaction with any Action Provider or the Flows Service via the CLI, a
-text prompt will appear directing the user to a web URL where that can proceed
+text prompt will appear directing the user to a web URL where they can proceed
 through an authentication process using Globus Auth to consent to the service
 they are using the CLI to interact with. This typically only needs to be done
 once, the first time a particular service is invoked. Subsequently, the cached

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -45,16 +45,16 @@ SDK in a Python script:
     off with the CLI interface.
 
 Use of the CLI and SDK to invoke any services requires authentication. Upon
-first interaction with any Action Provider or the Flows Service, a
-browser window will be opened to proceed through an Authentication
-process using Globus Auth to consent for use by the CLI with the
-service it is interacting with. This typically only needs to be done
+first interaction with any Action Provider or the Flows Service via the CLI, a
+text prompt will appear directing the user to a web URL where that can proceed
+through an authentication process using Globus Auth to consent to the service
+they are using the CLI to interact with. This typically only needs to be done
 once, the first time a particular service is invoked. Subsequently, the cached
 authentication information will be used. Authentication information is
-cached in the file ``~/.globus-automate.cfg``.
+cached in the file ``~/.globus_automate_tokens.json``.
 
 It is recommended that this file be protected. If re-authentication or
 re-consent is needed, the file may be deleted. This will remove
 consents to **all** Action Providers and the Flows service. The file
-is in ``ini`` format with section names based on the "scope". It may be
+is in ``json`` format with section names based on the ``scope``. It may be
 edited to remove particular scopes if done with care.

--- a/docs/source/using_cli_and_flows.rst
+++ b/docs/source/using_cli_and_flows.rst
@@ -29,7 +29,7 @@ Tips on using the CLI tool
 
    In most cases, use of a file is easier and more flexible. The tool will automatically detect whether the content is formatted JSON or if it specifies the name of a file.
 
-3. In almost all cases, the output from each command will be in JSON format. The tool will format the output to try to improve readability. However, you may wish to filter the output using pipes and further command line tools such as ``grep`` or ``jq``. When errors occur, a Python traceback is printed, with the content of the Automate API error in the exception message.
+3. In almost all cases, the output from each command will be in JSON format. The tool will format the output to try to improve readability. However, you may wish to filter the output using pipes and further command line tools such as ``grep`` or ``jq``.
 
 Working with Actions
 --------------------

--- a/docs/source/using_cli_and_flows.rst
+++ b/docs/source/using_cli_and_flows.rst
@@ -82,7 +82,9 @@ The most important information for our next step is the ``input_schema`` element
 Running
 ^^^^^^^
 
-The first step to prepare for running the Action is to create a file containing the input we want to provide when we run the Action. We'll call the file ``hello_input.json`` and will contain the following:
+The first step to prepare for running the Action is to create a file containing
+the input we want to provide when we run the Action. We'll call the file
+``hello_input.json`` and will contain the following:
 
 .. code-block:: JSON
 
@@ -91,7 +93,10 @@ The first step to prepare for running the Action is to create a file containing 
     "sleep_time": 60
   }
 
-This input conforms to the ``input_schema`` from the introspect call, and specifies that we will have the Action echo our name back to us and that it will "sleep" for 60 seconds until the Action is complete. We'll use this sleep time to demonstrate monitoring the state of an Action below.
+This input conforms to the ``input_schema`` from the introspect call, and
+specifies that we will have the Action echo our name back to us and that it
+will "sleep" for 60 seconds until the Action is complete. We'll use this sleep
+time to demonstrate monitoring the state of an Action below.
 
 We can run the action using the following command:
 
@@ -115,10 +120,13 @@ If the command is formatted properly, the resulting output will look like the fo
     "start_time": "<current_time>"
   }
 
-The output from this command is referred to as an "Action Status" document, and as you will see, this format is the result of all operations for working with Actions.
-The ``action_id`` is an identifier associated with this execution of the Action and will be used later.
+The output from this command is referred to as an "Action Status" document, and
+as you will see, this format is the result of all operations for working with
+Actions. The ``action_id`` is an identifier associated with this execution of the Action
+and will be used later.
 
-The ``status`` value of ``ACTIVE`` indicates that the Action is still considered to be executing. The possible values for ``status`` are:
+The ``status`` value of ``ACTIVE`` indicates that the Action is still considered
+to be executing. The possible values for ``status`` are:
 
 *  ``ACTIVE``: The Action is still running and making progress towards completion.
 
@@ -128,24 +136,71 @@ The ``status`` value of ``ACTIVE`` indicates that the Action is still considered
 
 *  ``FAILED``: The Action has stopped running due to some error condition. It cannot make progress towards a successful completion.
 
-Because we specified a ``sleep_time`` value of 60 in our example input, the Action will remain in this state for 60 seconds. The ``details`` portion will be specific to every Action and is the output or result of running the Action. This Action always includes the value ``"Hello": "World"`` and the property ``hello`` with the value passed in the ``echo_string``.  The ``release_after`` value provides the number of seconds, after the Action has completed, that the result from the Action will automatically be removed. Until that amount of time has elapsed after the Action completes, we can continue to retrieve the result of the Action as we show in the next section.
+Because we specified a ``sleep_time`` value of 60 in our example input, the
+Action will remain in this state for 60 seconds. The ``details`` portion will
+be specific to every Action and is the output or result of running the Action.
+This Action always includes the value ``"Hello": "World"`` and the property
+``hello`` with the value passed in the ``echo_string``.  The ``release_after``
+value provides the number of seconds, after the Action has completed, that the
+result from the Action will automatically be removed. Until that amount of time
+has elapsed after the Action completes, we can continue to retrieve the result
+of the Action as we show in the next section.
+
+It's also possible to delegate Action access to other Globus Auth identities
+when running the Action. By providing the ``monitor-by`` option, you can
+delegate read-only access to other users or groups, allowing them to retrieve
+the Action's execution state (see :ref:`retrieving_status`). By providing the
+``manage-by`` option, you delegate write access to other users or groups,
+allowing them to alter the Action's execution state (see
+:ref:`canceling_and_releasing`).
+
+Taking the example above, if we wanted to delegate read access to a Globus Group
+with ID ``00000000-0000-0000-0000-000000000000`` and delegate admin access to
+another Globus user with user ID ``00000000-0000-0000-0000-000000000000`` to the
+executed Action, we would run:
+
+.. code-block:: BASH
+
+    globus-automate action run --action-url \
+        https://actions.globus.org/hello_world --body hello_input.json \
+        --monitor-by urn:globus:groups:id:00000000-0000-0000-0000-000000000000 \
+        --manage-by urn:globus:auth:identity:00000000-0000-0000-0000-000000000000
+
+.. admonition:: Tip
+    :class: tip
+
+    You can specify each of the --monitor-by and --manage-by flags multiple
+    times to provide multiple identities with read or write access on the
+    Action.
+
+.. _retrieving_status:
 
 Retrieving Status
 ^^^^^^^^^^^^^^^^^
 
-Once an Action has been run, we can monitor or retrieve its status as follows:
+Once an Action has been run, the user who initiated the Action or anyone in
+the Action's ``monitor_by`` field can monitor or retrieve its status as follows:
 
 .. code-block:: BASH
 
     globus-automate action status --action-url https://actions.globus.org/hello_world <action_id>
 
-where the ``action_id`` is the value returned from the ``action run`` command from above. The output will be an Action status, similar to the output from the ``action run``. If at least 60 seconds have passed since the Action was started in our example, the ``status`` field will have the value ``SUCCEEDED``. When it is done, a ``completion_time`` field will be present indicating when the Action reached its final state. The request for status may be repeated as often as you wish until the Action's status has been "released" as described below.
+where the ``action_id`` is the value returned from the ``action run`` command
+from above. The output will be an Action status, similar to the output from the
+``action run``. If at least 60 seconds have passed since the Action was started
+in our example, the ``status`` field will have the value ``SUCCEEDED``. When it
+is done, a ``completion_time`` field will be present indicating when the Action
+reached its final state. The request for status may be repeated as often as you
+wish until the Action's status has been "released" as described below.
 
+.. _canceling_and_releasing:
 
 Canceling and Releasing
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-An Action which is running, but which is no longer needed may be canceled using a command of the form:
+An Action which is running, but which is no longer needed, may be canceled (or
+released) by the user who initiated the Action execution or anyone in the
+Action's ``manage_by`` field using a command of the form:
 
 .. code-block:: BASH
 
@@ -169,33 +224,91 @@ As described in the section on :ref:`flows_concept`, a Flow is a combination of 
 .. note::
    This section does not provide details on creating new Flows. This is covered in greater detail in the section on :ref:`flows_authoring`.
 
-Finding and displaying Flows
+Finding and Displaying Flows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following command will list the flows available for your use:
+When a Flow is deployed to Automate, the creator can specify which identities
+the Flow should be visible to and which identities the Flow should be runnable
+by. As the names suggest, users in a Flow's ``visible_to`` field will be able to
+query the service to view a Flow's definition and metadata. Users in a Flow's
+``runnable_by`` field will be able to run an instance of the Flow.
+
+The following command will list the Flows you have created:
 
 .. code-block:: BASH
 
     globus-automate flow list
 
-This outputs a list of flows, where the description of each flow carries the same fields as the output from ``globus-automate action introspect`` described above. This emphasizes again the similarity between Flows and Actions. The ``title`` and ``description`` fields may be helpful in determining what a Flow does and what its purpose is. Like Actions, the ``input_schema`` may define what is required of the input when running the flow. However, not all Flows are required to define an ``input_schema`` as a convenience to Flow authors who may not be familiar with creating JSON Schema specifications. Importantly, each entry in the list of Flows will also contain a value for ``id`` which we refer to as the "Flow id" and denote as ``flow_id`` below. This value will be used for further interacting with a particular Flow. For example, to display information about a single Flow you may use:
+To view Flows which are visible or runnable by you as well, run the following
+command:
+
+.. code-block:: BASH
+
+    globus-automate flow list \
+        --role created_by \
+        --role visible_to \
+        --role runnable_by
+
+This outputs a list of Flows, where the description of each flow carries the
+same fields as the output from ``globus-automate action introspect`` described
+above. This emphasizes again the similarity between Flows and Actions. The
+``title`` and ``description`` fields may be helpful in determining what a Flow
+does and what its purpose is. Like Actions, the ``input_schema`` may define what
+is required of the input when running the flow. However, not all Flows are
+required to define an ``input_schema`` as a convenience to Flow authors who may
+not be familiar with creating JSON Schema specifications. Importantly, each
+entry in the list of Flows will also contain a value for ``id`` which we refer
+to as the "Flow id" and denote as ``flow_id`` below. This value will be used for
+further interacting with a particular Flow.
+
+To display information about a single Flow you may use:
 
 .. code-block:: BASH
 
     globus-automate flow display <flow_id>
 
-When focusing on one Flow, it is also useful to notice the field ``definition``. This is the actual encoding of the Flow as it was created and deployed by the Flow's author. Looking at this value may give further information about how the Flow works. This can be useful both to determine if a Flow performs the function you desire, but also as a method to see how other Flows have been defined if you are interested in creating new Flows.
+Or, to visualize the Flow:
+
+.. code-block:: BASH
+
+    globus-automate flow display <flow_id> --format image
+
+When focusing on one Flow, it is also useful to notice the field ``definition``.
+This is the actual encoding of the Flow as it was created and deployed by the
+Flow's author. Looking at this value may give further information about how the
+Flow works. This can be useful both to determine if a Flow performs the function
+you desire, but also as a method to see how other Flows have been defined if you
+are interested in creating new Flows.
 
 Executing and Monitoring Flows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Execution and monitoring of Flows follows the same pattern as Actions: the run/status/cancel/release pattern is the same. We provide the following flows-specific commands to perform these tasks:
+Execution and monitoring of Flows follows the same pattern as Actions: the
+run/status/cancel/release pattern is the same.
+
+When initiating a Flow run, you can delegate access to the Flow instance to
+other Globus Auth identities. By providing the ``monitor-by`` option, you can
+delegate read-only access to other users or groups, allowing them to retrieve
+it execution state. By providing the ``manage-by`` option, you delegate write
+access to other users or groups, allowing them to alter its execution state. In
+the example below, we show how to run an instance of a Flow and delegate monitor
+access to a Globus Group:
 
 .. code-block:: BASH
 
-    globus-automate flow run --flow-input input.json <flow_id>
+    globus-automate flow run <flow_id> --flow-input input.json \
+        --monitor-by urn:globus:groups:id:00000000-0000-0000-0000-000000000000
 
-This acts like ``globus-automate action run`` with the flow id rather than the ``action_url`` specifying the "name" of the entity to be run. The output, like for Actions, will be an Action status document including an ``action_id`` which is used in the following commands:
+.. note::
+
+    If no ``manage_by`` or ``monitor_by`` values are specified, only the
+    identity instantiating the Flow run is allowed to monitor or manage a Flow's
+    running state.
+
+This acts like ``globus-automate action run`` with the flow id rather than the
+``action_url`` specifying the "name" of the Action to be run. The output, like
+for Actions, will be an Action status document including an ``action_id`` which
+is used in the following commands:
 
 .. code-block:: BASH
 
@@ -209,30 +322,70 @@ This acts like ``globus-automate action run`` with the flow id rather than the `
 
     globus-automate flow action-release --flow-id <flow_id> <action_id>
 
-For each of these, the ``details`` provides information about the most recent, potentially final, state executed by the Flow. However, as the Flow may execute many states, it is useful to be able to see what states have been executed and what their input and output have been. This can be seen via the "log" of the Flow execution as follows:
+For each of these, the ``details`` provides information about the most recent,
+potentially final, state executed by the Flow. However, as the Flow may execute
+many states, it is useful to be able to see what states have been executed and
+what their input and output have been. This can be seen via the "log" of the
+Flow execution as follows:
 
 .. code-block:: BASH
 
     globus-automate flow action-log --flow-id <flow_id> <action_id>
 
-The log may have a large number of entries. You can request more entries be returned using the option ``-limit N`` where ``N`` is the number of log entries to return. The default value is 10.
+The log may have a large number of entries. You can request more entries be
+returned using the option ``-limit N`` where ``N`` is the number of log entries
+to return. The default value is 10.
 
 Creating and managing Flows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Many users will only ever use Flows created by others, so they may not necessarily need to understand how to create Flows including the commands listed in this section. For those that are creating new Flows, the first step is to deploy a Flow as follows:
+Many users will only ever use Flows created by others, so they may not
+necessarily need to understand how to create Flows including the commands
+listed in this section. For those that have created a Flow, the first step is
+to deploy a Flow as follows:
 
 .. code-block:: BASH
 
     globus-automate flow deploy --title <title> --definition <Flow definition JSON> --input-schema <Input schema JSON> --visible-to <urn of user or group which can see this Flow> --runnable-by <urn of user or group which can run this Flow> --administered-by <urn of user or group who can maintain this flow>
 
-The output will be the Flow description as displayed by the ``flow display`` command above. These command line options provide the values for the similarly named fields in the Flow description. Of these, only ``title`` and ``definition`` are required. To aid users in using your Flow, we highly recommend the use of ``input-schema`` as it provides them both a form of documentation and assurance at run-time that the input they provide is correct for executing the Flow. By providing a value or values to ``administered-by`` you grant rights to others for updating or eventually removing the Flow you have deployed. Commands for updating and removing flows are as follows.
+When deployed this way, only the identity that deployed the Flow will be able to
+view the Flow and only they will be able to run an instance of the Flow. When
+deploying, it's possible to specify who should be able to see and run the Flow.
+Using the ``visible_to`` flag, you can indicate which Globus identities can view
+the deployed Flow, or set it to ``public``, which creates a Flow viewable by
+anyone. Using the ``runnable_by`` flag, you can indicate which Globus ideneties
+can run an instance of the deployed Flow, or set a value of
+``all_authenticated_users`` which allows any authenticated user to run an
+instance of the Flow.
+
+Below, we demonstrate how to deploy a Flow that is ``visible_to`` a single
+Globus group and ``runnable_by`` any authenticated user:
+
+.. code-block:: BASH
+
+    globus-automate flow deploy --title <title> \
+        --definition <Flow definition JSON> \
+        --input-schema <Input schema JSON> \
+        --visible-to urn:globus:groups:id:00000000-0000-0000-0000-000000000000 \
+        --runnable-by all_authenticated_users
+
+Once deployed, the output will be the Flow description as displayed by the
+``flow display`` command above. These command line options provide the values
+for the similarly named fields in the Flow description. Of these, only ``title``
+and ``definition`` are required. To aid users in using your Flow, we highly
+recommend the use of ``input-schema`` as it provides them both a form of
+documentation and assurance at run-time that the input they provide is correct
+for executing the Flow. By providing a value or values to ``administered-by``
+you grant rights to others for updating or eventually removing the Flow you have
+deployed. Commands for updating and removing flows are as follows.
 
 .. code-block:: BASH
 
     globus-automate flow update --title <title> --definition <Flow definition JSON> --input-schema <Input schema JSON> --visible-to <urn of user or group which can see this Flow> --runnable-by <urn of user or group which can run this Flow> --administered-by <urn of user or group who can maintain this flow> <flow_id>
 
-This will update any of the fields or description of the Flow, including the Flow definition itself. Note the ``flow_id`` field is present at the end of the command line.
+This will update any of the fields or description of the Flow, including the
+Flow definition itself. Note the ``flow_id`` field is present at the end of the
+command line.
 
 Deleting a Flow is done via:
 
@@ -240,6 +393,10 @@ Deleting a Flow is done via:
 
     globus-automate flow delete <flow_id>
 
-Care should be taken when issuing this command. There is no further prompting to insure the flow should really be deleted. After deletion, no record of the Flow definition or its execution history (i.e. the ``flow action-*`` commands) is maintained.
+Care should be taken when issuing this command. There is no further prompting to
+ensure the flow should really be deleted. After deletion, no record of the Flow
+definition or its execution history (i.e. the ``flow action-*`` commands) is
+maintained.
 
-The bulk of the effort in creating flows is in authoring their definition which is covered in the section :ref:`flows_authoring`.
+The bulk of the effort in creating flows is in authoring their definition which
+is covered in the section :ref:`flows_authoring`.

--- a/globus_automate_client/action_client.py
+++ b/globus_automate_client/action_client.py
@@ -63,12 +63,16 @@ class ActionClient(BaseClient):
 
         :param body: The Action Provider specific input required to execute an
             Action payload
-        :param request_id: An optional identifier that serves to de-deplicate
+        :param request_id: An optional identifier that serves to de-duplicate
             requests to the Action Provider
         :param manage_by: A series of Globus identities which may alter
-            this Action's execution
+            this Action's execution. The principal value is the user's or
+            group's UUID prefixed with either 'urn:globus:groups:id:' or
+            'urn:globus:auth:identity:'
         :param monitor_by: A series of Globus identities which may
-            view the state of this Action
+            view the state of this Action. The principal value is the user's or
+            group's UUID prefixed with either 'urn:globus:groups:id:' or
+            'urn:globus:auth:identity:'
         """
         if request_id is None:
             request_id = str(uuid.uuid4())

--- a/globus_automate_client/cli/actions.py
+++ b/globus_automate_client/cli/actions.py
@@ -86,12 +86,16 @@ def action_run(
     ),
     manage_by: List[str] = typer.Option(
         None,
-        help="A principal which may change the execution of the Action. [repeatable]",
+        help="A principal which may change the execution of the Action. The principal "
+        "is the user's or group's UUID prefixed with either 'urn:globus:groups:id:' "
+        "or 'urn:globus:auth:identity:' [repeatable]",
         callback=principal_validator,
     ),
     monitor_by: List[str] = typer.Option(
         None,
-        help="A principal which may view the state of the Action. [repeatable]",
+        help="A principal which may view the state of the Action. The principal "
+        "is the user's or group's UUID prefixed with either 'urn:globus:groups:id:' "
+        "or 'urn:globus:auth:identity:' [repeatable]",
         callback=principal_validator,
     ),
     verbose: bool = verbosity_option,

--- a/globus_automate_client/cli/auth.py
+++ b/globus_automate_client/cli/auth.py
@@ -7,6 +7,7 @@ from json import JSONDecodeError
 from typing import Any, Dict, List, NamedTuple, Optional, Set
 
 import click
+import typer
 from globus_sdk import AuthClient, GlobusAPIError, NativeAppAuthClient
 from globus_sdk.auth.token_response import OAuthTokenResponse
 from globus_sdk.authorizers import (
@@ -150,7 +151,7 @@ def _get_globus_sdk_native_client(
 
 def safeprint(s):
     try:
-        print(s)
+        typer.secho(s)
         sys.stdout.flush()
     except IOError:
         pass
@@ -168,13 +169,15 @@ def _do_login_for_scopes(
         refresh_tokens=True,
         prefill_named_grant=label,
     )
-    linkprompt = "Please log into Globus here"
-    safeprint(
-        "{0}:\n{1}\n{2}\n{1}\n".format(
-            linkprompt, "-" * len(linkprompt), native_client.oauth2_get_authorize_url()
-        )
+
+    linkprompt = (
+        "Please log into Globus here:\n"
+        "----------------------------\n"
+        f"{native_client.oauth2_get_authorize_url()}\n"
+        "----------------------------\n"
     )
-    auth_code = click.prompt("Enter the resulting Authorization Code here").strip()
+    safeprint(linkprompt)
+    auth_code = typer.prompt("Enter the resulting Authorization Code here")
     return native_client.oauth2_exchange_code_for_tokens(auth_code)
 
 

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -416,7 +416,7 @@ def flow_list(
     except GlobusAPIError as err:
         response = err
 
-    format_and_echo(flows, output_format.get_dumper(), verbose=verbose)
+    format_and_echo(response, output_format.get_dumper(), verbose=verbose)
 
 
 @app.command("display")

--- a/globus_automate_client/cli/rich_rendering.py
+++ b/globus_automate_client/cli/rich_rendering.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional
+from typing import Callable, Optional
 
 from rich.console import RenderGroup
 from rich.live import Live
@@ -71,9 +71,31 @@ class CLIContent:
         # If the CLIContent will no longer receive updates, omit the spinner.
         if self.done:
             return self.text
-
         return RenderGroup(self.text, self.spinner)
 
 
+class PauseableLive(Live):
+    """
+    We need this hack to prevent the underlying Live thread from rewriting
+    stdout when we're attempting to get input from the user.
+    """
+
+    live_refresher: Optional[Callable] = None
+
+    def pause_live(self):
+        """
+        Set the Live thread's refresh method to temporarily do nothing.
+        """
+        self.live_refresher = self._refresh_thread.live.refresh
+        self._refresh_thread.live.refresh = lambda *args: None
+
+    def resume_live(self):
+        """
+        Restore the Live thread's refresh method allowing it to do its thing.
+        """
+        if self.live_refresher is not None:
+            self._refresh_thread.live.refresh = self.live_refresher
+
+
 cli_content = CLIContent(4)
-live_content = Live(cli_content, refresh_per_second=20)
+live_content = PauseableLive(cli_content, refresh_per_second=20)

--- a/globus_automate_client/cli/rich_rendering.py
+++ b/globus_automate_client/cli/rich_rendering.py
@@ -86,8 +86,9 @@ class PauseableLive(Live):
         """
         Set the Live thread's refresh method to temporarily do nothing.
         """
-        self.live_refresher = self._refresh_thread.live.refresh
-        self._refresh_thread.live.refresh = lambda *args: None
+        if self._refresh_thread is not None:
+            self.live_refresher = self._refresh_thread.live.refresh
+            self._refresh_thread.live.refresh = lambda *args: None
 
     def resume_live(self):
         """

--- a/globus_automate_client/client_helpers.py
+++ b/globus_automate_client/client_helpers.py
@@ -57,9 +57,9 @@ def cli_authorizer_callback(**kwargs):
     flow_scope = kwargs["flow_scope"]
     client_id = kwargs["client_id"]
 
-    live_content.stop()
+    live_content.pause_live()
     authorizer = get_cli_authorizer(flow_url, flow_scope, client_id)
-    live_content.start()
+    live_content.resume_live()
     return authorizer
 
 

--- a/globus_automate_client/client_helpers.py
+++ b/globus_automate_client/client_helpers.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from globus_automate_client.action_client import ActionClient
 from globus_automate_client.cli.auth import CLIENT_ID, get_cli_authorizer
+from globus_automate_client.cli.rich_rendering import live_content
 from globus_automate_client.flows_client import (
     MANAGE_FLOWS_SCOPE,
     PROD_FLOWS_BASE_URL,
@@ -55,7 +56,11 @@ def cli_authorizer_callback(**kwargs):
     flow_url = kwargs["flow_url"]
     flow_scope = kwargs["flow_scope"]
     client_id = kwargs["client_id"]
-    return get_cli_authorizer(flow_url, flow_scope, client_id)
+
+    live_content.stop()
+    authorizer = get_cli_authorizer(flow_url, flow_scope, client_id)
+    live_content.start()
+    return authorizer
 
 
 def create_flows_client(

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -426,7 +426,13 @@ class FlowsClient(BaseClient):
         )
 
     def run_flow(
-        self, flow_id: str, flow_scope: Optional[str], flow_input: Mapping, **kwargs
+        self,
+        flow_id: str,
+        flow_scope: Optional[str],
+        flow_input: Mapping,
+        manage_by: Optional[List[str]] = None,
+        monitor_by: Optional[List[str]] = None,
+        **kwargs,
     ) -> GlobusHTTPResponse:
         """
         Run an instance of a deployed Flow with the given input.
@@ -440,6 +446,16 @@ class FlowsClient(BaseClient):
         :param flow_input: A Flow-specific dictionary specifying the input
             required for the Flow to run.
 
+        :param manage_by: A series of Globus identities which may alter
+            this Flow instance's execution. The principal value is the user's or
+            group's UUID prefixed with either 'urn:globus:groups:id:' or
+            'urn:globus:auth:identity:'
+
+        :param monitor_by: A series of Globus identities which may view this
+            Flow instance's execution state. The principal value is the user's
+            or group's UUID prefixed with either 'urn:globus:groups:id:' or
+            'urn:globus:auth:identity:'
+
         :param kwargs: Any additional kwargs passed into this method are passed
             onto the Globus BaseClient. If there exists an "authorizer" keyword
             argument, that gets used to run the Flow operation. Otherwise the
@@ -448,7 +464,7 @@ class FlowsClient(BaseClient):
         authorizer = self._get_authorizer_for_flow(flow_id, flow_scope, kwargs)
         flow_url = f"{self.base_url}/flows/{flow_id}"
         ac = ActionClient.new_client(flow_url, authorizer)
-        return ac.run(flow_input, **kwargs)
+        return ac.run(flow_input, manage_by=manage_by, monitor_by=monitor_by, **kwargs)
 
     def flow_action_status(
         self, flow_id: str, flow_scope: Optional[str], flow_action_id: str, **kwargs


### PR DESCRIPTION
I started updating the docs but realized it would be more effort than I thought it would be. This PR address some concerns around what exactly an acceptable principal value is, both in the `CLI` and `SDK` levels for `ActionClients` and `FlowsClients`. It also explicitly adds the `manage_by` and `monitor_by` arguments to the `FlowClient.run()` method for better visibility (they used to just be lumped into `kwargs` and passed onto the underlying `ActionClient.run()` call).

Also:
- Fixes bugs in live rendering where Globus Auth logins weren't displaying correctly when watching an executing Action.
- Updates `flow lint` output to clearly indicate the linting results, instead of outputting Flow definitions.
- Adds support to `flow display` for visualizing local or remote Flow definitions.
- Removes faulty visualization options on flow_list