### PR TITLE
Mock imports so they don't have to be installed to build docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,14 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../../"))
-autodoc_mock_imports = ["globus_sdk", "jsonschema", "graphviz"]
+autodoc_mock_imports = [
+    "globus_sdk",
+    "jsonschema",
+    "graphviz",
+    "click",
+    "typer",
+    "rich",
+]
 autodoc_typehints = "description"
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
When building the docs, the `autoclass` documentation wasn't building because readthedocs couldn't find some modules installed. This PR explicitly tells sphinx to mock those imports (`click`, `typer`, `rich`) so that the documentation can build.