### PR TITLE
Flows List default roles are Flows API default roles

### DIFF
--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -364,7 +364,7 @@ def flow_lint(
 @app.command("list")
 def flow_list(
     roles: List[FlowRole] = typer.Option(
-        [FlowRole.created_by],
+        [],
         "--role",
         "-r",
         help="Display Flows where you have the selected role. [repeatable]",


### PR DESCRIPTION
It's happened often enough where CLI users are confused why they get different Flow output on the Flow List command. This PR removes the default role filtering (used to default to created_by) so that if the CLI command is run without any role filters, the results returned are dependent on the API.