### PR TITLE
Set tokenfile to R/W by owner only

### DIFF
--- a/globus_automate_client/cli/auth.py
+++ b/globus_automate_client/cli/auth.py
@@ -156,6 +156,10 @@ class TokenCache:
 
         if self.modified:
             with open(self.token_store, "w") as f:
+                if isinstance(self.token_store, pathlib.Path):
+                    self.token_store.chmod(0o600)
+                else:
+                    os.chmod(self.token_store, 0o600)
                 jsonable = TokenCache._make_jsonable(self.tokens)
                 json.dump(
                     jsonable,


### PR DESCRIPTION
Inspired by announcements related to Search client which may also
impact other uses of the globus sdk tokenstore (which maybe should
include this client at some point as well).
