### PR TITLE
Fixes formatting issue on Flow deploys

### DIFF
--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -211,9 +211,9 @@ def flow_deploy(
         result = err
     # Match up output format with input format
     if input_format is InputFormat.json:
-        format_and_echo(result, json.dumps, verbose=verbose)
+        format_and_echo(result, OutputFormat.json.get_dumper(), verbose=verbose)
     elif input_format is InputFormat.yaml:
-        format_and_echo(result, yaml.dump, verbose=verbose)
+        format_and_echo(result, OutputFormat.yaml.get_dumper(), verbose=verbose)
 
 
 @app.command("get")


### PR DESCRIPTION
When deploying a Flow, the output formatting would JSON/YAML dump without any indentation, resulting in a hard to deal with blob. This PR adds the indentation back into the command output.