### PR TITLE
Add license to output of pip show

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
   ]
 
 readme = "README.rst"
+license = "Apache-2.0"
 
 [tool.poetry.scripts]
 globus-automate = "globus_automate_client.cli.main:app"


### PR DESCRIPTION
This PR adds license info to the output of the `pip show globus-automate-client` command:

Before:
```
Name: globus-automate-client
Version: 0.11.4
Summary: Experimental client for the in-development Globus Automate services
Home-page: None
Author: Jim Pruyne
Author-email: pruyne@globus.org
License: None
Location: /usr/local/lib/python3.6/site-packages
Requires: typer, jsonschema, rich, globus-sdk, PyYAML, graphviz
Required-by:
```

After:
```
Name: globus-automate-client
Version: 0.11.4
Summary: Experimental client for the in-development Globus Automate services
Home-page: None
Author: Jim Pruyne
Author-email: pruyne@globus.org
License: Apache-2.0
Location: /Users/uriel/Projects/github.com/globus/globus-automate-client/.venv/lib/python3.6/site-packages
Requires: globus-sdk, jsonschema, PyYAML, graphviz, rich, typer
Required-by:
```