### PR TITLE
Fixes action_enumeration at the SDK level

### DIFF
--- a/globus_automate_client/cli/auth.py
+++ b/globus_automate_client/cli/auth.py
@@ -385,7 +385,6 @@ def get_cli_authorizer(
     action_url: str,
     action_scope: Optional[str],
     client_id: str = CLIENT_ID,
-    query_for_additional_consent: bool = False,
 ) -> Optional[AccessTokenAuthorizer]:
     if action_scope is None:
         # We don't know the scope which makes it impossible to get a token,

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -51,6 +51,9 @@ RUN_FLOWS_SCOPE = (
 RUN_STATUS_SCOPE = (
     "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run_status"
 )
+RUN_MANAGE_SCOPE = (
+    "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run_manage"
+)
 NULL_SCOPE = "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/null"
 
 ALL_FLOW_SCOPES = (
@@ -58,6 +61,7 @@ ALL_FLOW_SCOPES = (
     VIEW_FLOWS_SCOPE,
     RUN_FLOWS_SCOPE,
     RUN_STATUS_SCOPE,
+    RUN_MANAGE_SCOPE,
 )
 
 _FlowsClient = TypeVar("_FlowsClient", bound="FlowsClient")
@@ -686,7 +690,11 @@ class FlowsClient(BaseClient):
             for field, value in orderings.items():
                 builder.append(f"{field} {value}")
             params["orderby"] = ",".join(builder)
-        return self.get(f"/runs", params=params, **kwargs)
+
+        self.authorizer = self._get_authorizer_for_flow("", RUN_STATUS_SCOPE, kwargs)
+        response = self.get(f"/runs", params=params, **kwargs)
+        self.authorizer = self.flow_management_authorizer
+        return response
 
     def list_flow_actions(
         self,


### PR DESCRIPTION
This PR fixes a bug in `action_enumeration` in the SDK. When making the call, the FlowsClient would make the call using the management authorizer, which was typically the authorizer with consents to the MANGE_FLOWS scope: `https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/manage_flows`). It should have been making the call using an authorizer with consents to the RUN_STATUS scope: `https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run_status`. 

This wasn't an issue at the CLI level because the CLI would instantiate the FlowsClient where the management authorizer was an authorizer with consents to the RUN_STATUS scope rather than to the MANAGE_FLOWS scope. That meant that the CLI level FlowsClient could only be used to enumerate actions and would fail on other operations, which is ok since the CLI creates a single FlowsClient per call.

At the SDK, a single FlowsClient can (and should) make calls to the various different endpoints. This means that we need to dynamically pull an authorizer for the RUN_STATUS scope when using the `action_enumeration` method. This PR adds that functionality:

The order in which the authorizer is determined is:
- If an authorizer gets passed as a kwarg, that get's used to make the API call
- If the scope is provided, a token for that scope is generated using the authorizer_callback provided by the user.