### PR TITLE
Unifies CLI output display and adds tabular display

### DIFF
--- a/examples/flows/hello-consent/definition.json
+++ b/examples/flows/hello-consent/definition.json
@@ -1,0 +1,14 @@
+{
+    "StartAt": "HelloState",
+    "States": {
+        "HelloState": {
+            "Type": "Action",
+            "ActionUrl": "https://actions.automate.globus.org/hello_world",
+            "Parameters": {
+                "required_dependent_scope": "urn:globus:auth:scope:groups.api.globus.org:all"
+            },
+            "ResultPath": "$.FlowResult",
+            "End": true
+        }
+    }
+}

--- a/examples/flows/hello-consent/schema.json
+++ b/examples/flows/hello-consent/schema.json
@@ -1,0 +1,3 @@
+{
+    "additionalProperties": false
+}

--- a/globus_automate_client/cli/actions.py
+++ b/globus_automate_client/cli/actions.py
@@ -9,7 +9,11 @@ from globus_automate_client.cli.callbacks import (
     url_validator_callback,
 )
 from globus_automate_client.cli.constants import OutputFormat
-from globus_automate_client.cli.helpers import process_input, verbosity_option
+from globus_automate_client.cli.helpers import (
+    output_format_option,
+    process_input,
+    verbosity_option,
+)
 from globus_automate_client.cli.rich_helpers import RequestRunner
 from globus_automate_client.cli.rich_rendering import live_content
 from globus_automate_client.client_helpers import create_action_client
@@ -31,14 +35,7 @@ def action_introspect(
         callback=url_validator_callback,
     ),
     verbose: bool = verbosity_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
 ):
     """
     Introspect an Action Provider's schema.
@@ -90,14 +87,7 @@ def action_run(
         callback=principal_validator,
     ),
     verbose: bool = verbosity_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     label: str = typer.Option(
         None,
         "--label",
@@ -155,14 +145,7 @@ def action_status(
     ),
     action_id: str = typer.Argument(...),
     verbose: bool = verbosity_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     watch: bool = typer.Option(
         False,
         "--watch",
@@ -204,14 +187,7 @@ def action_resume(
     ),
     action_id: str = typer.Argument(...),
     verbose: bool = verbosity_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     watch: bool = typer.Option(
         False,
         "--watch",
@@ -275,14 +251,7 @@ def action_cancel(
     ),
     action_id: str = typer.Argument(...),
     verbose: bool = verbosity_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
 ):
     """
     Terminate a running Action by its ACTION_ID.
@@ -309,14 +278,7 @@ def action_release(
     ),
     action_id: str = typer.Argument(...),
     verbose: bool = verbosity_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
 ):
     """
     Remove an Action's execution history by its ACTION_ID.

--- a/globus_automate_client/cli/actions.py
+++ b/globus_automate_client/cli/actions.py
@@ -2,20 +2,15 @@ import functools
 from typing import List
 
 import typer
-from globus_sdk import GlobusAPIError
 
 from globus_automate_client.cli.callbacks import (
     input_validator,
     principal_validator,
     url_validator_callback,
 )
-from globus_automate_client.cli.constants import InputFormat, OutputFormat
-from globus_automate_client.cli.helpers import (
-    format_and_echo,
-    process_input,
-    request_runner,
-    verbosity_option,
-)
+from globus_automate_client.cli.constants import OutputFormat
+from globus_automate_client.cli.helpers import process_input, verbosity_option
+from globus_automate_client.cli.rich_helpers import RequestRunner
 from globus_automate_client.cli.rich_rendering import live_content
 from globus_automate_client.client_helpers import create_action_client
 
@@ -49,11 +44,7 @@ def action_introspect(
     Introspect an Action Provider's schema.
     """
     ac = create_action_client(action_url, action_scope)
-    try:
-        result = ac.introspect()
-    except GlobusAPIError as err:
-        result = err
-    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
+    RequestRunner(ac.introspect, format=output_format, verbose=verbose).run_and_render()
 
 
 @app.command("run")
@@ -107,14 +98,6 @@ def action_run(
         case_sensitive=False,
         show_default=True,
     ),
-    input_format: InputFormat = typer.Option(
-        InputFormat.json,
-        "--input",
-        "-i",
-        help="Input format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
     label: str = typer.Option(
         None,
         "--label",
@@ -132,20 +115,29 @@ def action_run(
     """
     Launch an Action.
     """
-    parsed_body = process_input(body, input_format)
+    parsed_body = process_input(body)
     ac = create_action_client(action_url, action_scope)
     method = functools.partial(
         ac.run, parsed_body, request_id, manage_by, monitor_by, label=label
     )
-
     with live_content:
-        # Set watch to false here to immediately return after running the Action
-        result = request_runner(method, output_format, verbose, False)
-
-        if watch and not isinstance(result, GlobusAPIError):
+        result = RequestRunner(
+            method,
+            format=output_format,
+            verbose=verbose,
+            watch=watch,
+            run_once=True,
+        ).run_and_render()
+        if not result.is_api_error and watch:
             action_id = result.data.get("action_id")
             method = functools.partial(ac.status, action_id)
-            request_runner(method, output_format, verbose, watch)
+            RequestRunner(
+                method,
+                format=output_format,
+                verbose=verbose,
+                watch=watch,
+                run_once=False,
+            ).run_and_render()
 
 
 @app.command("status")
@@ -185,7 +177,9 @@ def action_status(
     ac = create_action_client(action_url, action_scope)
     method = functools.partial(ac.status, action_id)
     with live_content:
-        request_runner(method, output_format, verbose, watch)
+        RequestRunner(
+            method, format=output_format, verbose=verbose, watch=watch, run_once=False
+        ).run_and_render()
 
 
 @app.command("resume")
@@ -218,14 +212,28 @@ def action_resume(
         case_sensitive=False,
         show_default=True,
     ),
+    watch: bool = typer.Option(
+        False,
+        "--watch",
+        "-w",
+        help="Continuously poll this Action until it reaches a completed state. ",
+        show_default=True,
+    ),
 ):
     """
     Resume an inactive Action by its ACTION_ID.
     """
     ac = create_action_client(action_url, action_scope=action_scope)
-    try:
-        if query_for_inactive_reason:
-            result = ac.status(action_id)
+    if query_for_inactive_reason:
+        result = RequestRunner(
+            functools.partial(ac.status, action_id),
+            format=output_format,
+            verbose=verbose,
+            watch=watch,
+            run_once=True,
+        ).run()
+
+        if not result.is_api_error:
             body = result.data
             status = body.get("status")
             details = body.get("details", {})
@@ -234,10 +242,22 @@ def action_resume(
                 required_scope = details.get("required_scope")
                 if required_scope is not None:
                     ac = create_action_client(action_url, action_scope=required_scope)
-        result = ac.resume(action_id)
-    except GlobusAPIError as err:
-        result = err
-    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
+
+    result = RequestRunner(
+        functools.partial(ac.resume, action_id),
+        format=output_format,
+        verbose=verbose,
+        watch=watch,
+        run_once=True,
+    ).run_and_render()
+    if not result.is_api_error and watch:
+        with live_content:
+            RequestRunner(
+                functools.partial(ac.status, action_id),
+                format=output_format,
+                verbose=verbose,
+                watch=watch,
+            ).run_and_render()
 
 
 @app.command("cancel")
@@ -268,11 +288,10 @@ def action_cancel(
     Terminate a running Action by its ACTION_ID.
     """
     ac = create_action_client(action_url, action_scope)
-    try:
-        result = ac.cancel(action_id)
-    except GlobusAPIError as err:
-        result = err
-    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
+    method = functools.partial(ac.cancel, action_id)
+    RequestRunner(
+        method, format=output_format, verbose=verbose, watch=False, run_once=True
+    ).run_and_render()
 
 
 @app.command("release")
@@ -303,11 +322,10 @@ def action_release(
     Remove an Action's execution history by its ACTION_ID.
     """
     ac = create_action_client(action_url, action_scope)
-    try:
-        result = ac.release(action_id)
-    except GlobusAPIError as err:
-        result = err
-    format_and_echo(result, output_format.get_dumper(), verbose=verbose)
+    method = functools.partial(ac.release, action_id)
+    RequestRunner(
+        method, format=output_format, verbose=verbose, watch=False, run_once=True
+    ).run_and_render()
 
 
 if __name__ == "__main__":

--- a/globus_automate_client/cli/callbacks.py
+++ b/globus_automate_client/cli/callbacks.py
@@ -117,7 +117,8 @@ def flows_endpoint_envvar_callback(default_value: str) -> str:
 def input_validator(body: str) -> str:
     """
     Checks if input is a file and loads its contents, otherwise returns the
-    supplied string.
+    supplied string. This validator will also attempt to parse the string as a
+    dict, failing if the parsing fails.
     """
     # Callbacks are run regardless of whether an option was explicitly set.
     # Handle the scenario where the default value for an option is empty
@@ -142,6 +143,13 @@ def input_validator(body: str) -> str:
             # is a directory, so we have to assume the string is JSON and
             # continue
             pass
+    try:
+        json.loads(body)
+    except json.JSONDecodeError:
+        try:
+            yaml.safe_load(body)
+        except yaml.YAMLError:
+            raise typer.BadParameter(f"Unable to load input as JSON or YAML")
     return body
 
 

--- a/globus_automate_client/cli/callbacks.py
+++ b/globus_automate_client/cli/callbacks.py
@@ -144,12 +144,14 @@ def input_validator(body: str) -> str:
             # continue
             pass
     try:
-        json.loads(body)
+        parsed_body = json.loads(body)
     except json.JSONDecodeError:
         try:
-            yaml.safe_load(body)
+            parsed_body = yaml.safe_load(body)
         except yaml.YAMLError:
             raise typer.BadParameter(f"Unable to load input as JSON or YAML")
+    if not isinstance(parsed_body, dict):
+        raise typer.BadParameter(f"Unable to load input as JSON or YAML")
     return body
 
 

--- a/globus_automate_client/cli/constants.py
+++ b/globus_automate_client/cli/constants.py
@@ -93,18 +93,19 @@ class RunLogOutputFormat(str, enum.Enum):
             self.graphviz_text(flow_log, flow_def)
 
     def graphviz_text(self, flow_log: GlobusHTTPResponse, flow_def: GlobusHTTPResponse):
-        definition = flow_def.data["definition"]
-        colors = state_colors_for_log(flow_log.data["entries"])
-        graphviz_out = graphviz_format(definition, colors)
+        graphviz_out = self._as_graphiz(flow_log, flow_def)
         typer.echo(graphviz_out.source)
 
     def graphviz_image(
         self, flow_log: GlobusHTTPResponse, flow_def: GlobusHTTPResponse
     ):
+        graphviz_out = self._as_graphiz(flow_log, flow_def)
+        graphviz_out.render("flows-output/graph", view=True, cleanup=True)
+
+    def _as_graphiz(self, flow_log: GlobusHTTPResponse, flow_def: GlobusHTTPResponse):
         definition = flow_def.data["definition"]
         colors = state_colors_for_log(flow_log.data["entries"])
-        graphviz_out = graphviz_format(definition, colors)
-        graphviz_out.render("flows-output/graph", view=True, cleanup=True)
+        return graphviz_format(definition, colors)
 
 
 class ImageOutputFormat(str, enum.Enum):

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -27,6 +27,7 @@ from globus_automate_client.cli.constants import (
 from globus_automate_client.cli.helpers import (
     flows_env_var_option,
     make_role_param,
+    output_format_option,
     parse_query_options,
     process_input,
     verbosity_option,
@@ -169,14 +170,7 @@ def flow_deploy(
     ),
     flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -214,14 +208,7 @@ def flow_deploy(
 @app.command("get")
 def flow_get(
     flow_id: uuid.UUID = typer.Argument(..., help="A deployed Flow's ID"),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     verbose: bool = verbosity_option,
     flows_endpoint: str = flows_env_var_option,
 ):
@@ -327,14 +314,7 @@ def flow_update(
     ),
     flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
 ):
     """
     Update a Flow.
@@ -551,14 +531,7 @@ def flow_display(
 @app.command("delete")
 def flow_delete(
     flow_id: str = typer.Argument(...),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
 ):
@@ -612,14 +585,7 @@ def flow_run(
     ),
     flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     label: str = typer.Option(
         ...,
         "--label",
@@ -815,14 +781,7 @@ def flow_action_status(
         help="Continuously poll this Action until it reaches a completed state.",
         show_default=True,
     ),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     verbose: bool = verbosity_option,
 ):
     """
@@ -858,14 +817,7 @@ def flow_action_resume(
         ),
     ),
     flows_endpoint: str = flows_env_var_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     watch: bool = typer.Option(
         False,
         "--watch",
@@ -930,14 +882,7 @@ def flow_action_release(
         help="The scope this Flow uses to authenticate requests.",
         callback=url_validator_callback,
     ),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
 ):
@@ -966,14 +911,7 @@ def flow_action_cancel(
         help="The scope this Flow uses to authenticate requests.",
         callback=url_validator_callback,
     ),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
 ):
@@ -1203,14 +1141,7 @@ def flow_action_update(
     ),
     flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
 ):
     """
     Update a Run on the Flows service

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -1,19 +1,12 @@
 import functools
-import json
-import sys
 import uuid
-from enum import Enum
-from itertools import chain
-from typing import Any, List, Mapping, Optional, Union
+from typing import List, Optional
 
 import typer
-import yaml
-from globus_sdk import GlobusAPIError, GlobusHTTPResponse
 
 from globus_automate_client.cli.auth import CLIENT_ID
 from globus_automate_client.cli.callbacks import (
     flow_input_validator,
-    flows_endpoint_envvar_callback,
     input_validator,
     principal_or_all_authenticated_users_validator,
     principal_or_public_validator,
@@ -21,17 +14,30 @@ from globus_automate_client.cli.callbacks import (
     url_validator_callback,
 )
 from globus_automate_client.cli.constants import (
-    FlowDisplayFormat,
-    InputFormat,
+    ActionRole,
+    ActionRoleAllNames,
+    ActionStatus,
+    FlowRole,
+    FlowRoleAllNames,
+    ImageOutputFormat,
+    ListingOutputFormat,
     OutputFormat,
+    RunLogOutputFormat,
 )
 from globus_automate_client.cli.helpers import (
-    flow_log_runner,
-    format_and_echo,
+    flows_env_var_option,
+    make_role_param,
     parse_query_options,
     process_input,
-    request_runner,
     verbosity_option,
+)
+from globus_automate_client.cli.rich_helpers import (
+    FlowListDisplayFields,
+    LogCompletionDetetector,
+    RequestRunner,
+    RunEnumerateDisplayFields,
+    RunListDisplayFields,
+    RunLogDisplayFields,
 )
 from globus_automate_client.cli.rich_rendering import live_content
 from globus_automate_client.client_helpers import create_flows_client
@@ -40,101 +46,15 @@ from globus_automate_client.flows_client import (
     FlowValidationError,
     validate_flow_definition,
 )
-from globus_automate_client.graphviz_rendering import graphviz_format
-
-
-class FlowRole(str, Enum):
-    flow_viewer = "flow_viewer"
-    flow_starter = "flow_starter"
-    flow_administrator = "flow_administrator"
-    flow_owner = "flow_owner"
-
-
-class FlowRoleDeprecated(str, Enum):
-    created_by = "created_by"
-    visible_to = "visible_to"
-    runnable_by = "runnable_by"
-    administered_by = "administered_by"
-
-
-# Adapted from https://stackoverflow.com/questions/33679930/how-to-extend-python-enum
-FlowRoleAllNames = Enum(
-    "FlowRoleAllNames", [(i.name, i.value) for i in chain(FlowRole, FlowRoleDeprecated)]
-)
-
-
-class ActionRole(str, Enum):
-    run_monitor = "run_monitor"
-    run_manager = "run_manager"
-    run_owner = "run_owner"
-
-
-class ActionRoleDeprecated(str, Enum):
-    created_by = "created_by"
-    monitor_by = "monitor_by"
-    manage_by = "manage_by"
-
-
-ActionRoleAllNames = Enum(
-    "ActionRoleAllNames",
-    [(i.name, i.value) for i in chain(ActionRole, ActionRoleDeprecated)],
-)
-
-
-class ActionStatus(str, Enum):
-    succeeded = "SUCCEEDED"
-    failed = "FAILED"
-    active = "ACTIVE"
-    inactive = "INACTIVE"
-
-
-def _process_flow_input(flow_input: str, input_format) -> Mapping[str, Any]:
-    flow_input_dict = {}
-
-    if flow_input is not None:
-        if input_format is InputFormat.json:
-            try:
-                flow_input_dict = json.loads(flow_input)
-            except json.JSONDecodeError as e:
-                raise typer.BadParameter(f"Invalid JSON for input schema: {e}")
-        elif input_format is InputFormat.yaml:
-            try:
-                flow_input_dict = yaml.safe_load(flow_input)
-            except yaml.YAMLError as e:
-                raise typer.BadParameter(f"Invalid YAML for input schema: {e}")
-
-    return flow_input_dict
-
 
 app = typer.Typer(short_help="Manage Globus Automate Flows")
 
-_flows_env_var_option = typer.Option(
-    None,
-    hidden=True,
-    callback=flows_endpoint_envvar_callback,
-)
 
 _principal_description = (
     "The principal value is the user's Globus Auth username or their identity "
     "UUID in the form urn:globus:auth:identity:<UUID>. A Globus Group may also be "
     "used using the form urn:globus:groups:id:<GROUP_UUID>."
 )
-
-
-def _make_role_param(
-    roles_list: Optional[Union[List[FlowRoleAllNames], List[ActionRoleAllNames]]]
-) -> [Mapping[str, Any]]:
-    if roles_list is None:
-        return {"role": None}
-    elif len(roles_list) == 1:
-        return {"role": roles_list[0].value}
-    else:
-        typer.secho(
-            "Warning: Use of multiple --role options is deprecated",
-            sys.stderr,
-            fg=typer.colors.YELLOW,
-        )
-        return {"roles": [r.value for r in roles_list]}
 
 
 @app.callback()
@@ -247,13 +167,13 @@ def flow_deploy(
         case_sensitive=False,
         show_default=True,
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
-    input_format: InputFormat = typer.Option(
-        InputFormat.json,
-        "--input",
-        "-i",
-        help="Input format.",
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.json,
+        "--format",
+        "-f",
+        help="Output display format.",
         case_sensitive=False,
         show_default=True,
     ),
@@ -270,48 +190,47 @@ def flow_deploy(
     Deploy a new Flow.
     """
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
-    flow_dict = process_input(definition, input_format)
-    input_schema_dict = process_input(input_schema, input_format, " for input schema")
+    flow_dict = process_input(definition)
+    input_schema_dict = process_input(input_schema)
 
-    try:
-        result = fc.deploy_flow(
-            flow_dict,
-            title,
-            subtitle,
-            description,
-            keywords,
-            visible_to,
-            runnable_by,
-            administered_by,
-            subscription_id,
-            input_schema_dict,
-            validate_definition=validate,
-            dry_run=dry_run,
-        )
-    except GlobusAPIError as err:
-        result = err
-    # Match up output format with input format
-    if input_format is InputFormat.json:
-        format_and_echo(result, OutputFormat.json.get_dumper(), verbose=verbose)
-    elif input_format is InputFormat.yaml:
-        format_and_echo(result, OutputFormat.yaml.get_dumper(), verbose=verbose)
+    method = functools.partial(
+        fc.deploy_flow,
+        flow_dict,
+        title,
+        subtitle,
+        description,
+        keywords,
+        visible_to,
+        runnable_by,
+        administered_by,
+        subscription_id,
+        input_schema_dict,
+        validate_definition=validate,
+        dry_run=dry_run,
+    )
+    RequestRunner(method, format=output_format, verbose=verbose).run_and_render()
 
 
 @app.command("get")
 def flow_get(
     flow_id: uuid.UUID = typer.Argument(..., help="A deployed Flow's ID"),
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.json,
+        "--format",
+        "-f",
+        help="Output display format.",
+        case_sensitive=False,
+        show_default=True,
+    ),
     verbose: bool = verbosity_option,
-    flows_endpoint: str = _flows_env_var_option,
+    flows_endpoint: str = flows_env_var_option,
 ):
     """
     Get a Flow's definition as it exists on the Flows service.
     """
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
-    try:
-        result = fc.get_flow(str(flow_id))
-    except GlobusAPIError as err:
-        result = err
-    format_and_echo(result, verbose=verbose)
+    method = functools.partial(fc.get_flow, str(flow_id))
+    RequestRunner(method, format=output_format, verbose=verbose).run_and_render()
 
 
 @app.command("update")
@@ -406,13 +325,13 @@ def flow_update(
         case_sensitive=False,
         show_default=True,
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
-    input_format: InputFormat = typer.Option(
-        InputFormat.json,
-        "--input",
-        "-i",
-        help="Input format.",
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.json,
+        "--format",
+        "-f",
+        help="Output display format.",
         case_sensitive=False,
         show_default=True,
     ),
@@ -421,32 +340,28 @@ def flow_update(
     Update a Flow.
     """
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
-    flow_dict = process_input(definition, input_format)
-    input_schema_dict = process_input(input_schema, input_format, " for input schema")
+    flow_dict = process_input(definition)
+    input_schema_dict = process_input(input_schema)
 
-    try:
-        result = fc.update_flow(
-            flow_id,
-            flow_dict,
-            title,
-            subtitle,
-            description,
-            keywords,
-            flow_viewer,
-            flow_starter,
-            flow_administrator,
-            subscription_id,
-            input_schema_dict,
-            validate_definition=validate,
-            visible_to=visible_to,
-            runnable_by=runnable_by,
-            administered_by=administered_by,
-        )
-    except GlobusAPIError as err:
-        result = err
-    if result is None:
-        result = "No operation to perform"
-    format_and_echo(result, input_format.get_dumper(), verbose=verbose)
+    method = functools.partial(
+        fc.update_flow,
+        flow_id,
+        flow_dict,
+        title,
+        subtitle,
+        description,
+        keywords,
+        flow_viewer,
+        flow_starter,
+        flow_administrator,
+        subscription_id,
+        input_schema_dict,
+        validate_definition=validate,
+        visible_to=visible_to,
+        runnable_by=runnable_by,
+        administered_by=administered_by,
+    )
+    RequestRunner(method, format=output_format, verbose=verbose).run_and_render()
 
 
 @app.command("lint")
@@ -460,19 +375,11 @@ def flow_lint(
         prompt=True,
         callback=input_validator,
     ),
-    input_format: InputFormat = typer.Option(
-        InputFormat.json,
-        "--input",
-        "-i",
-        help="Input format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
 ):
     """
     Parse and validate a Flow definition by providing visual output.
     """
-    flow_dict = process_input(definition, input_format)
+    flow_dict = process_input(definition)
 
     try:
         validate_flow_definition(flow_dict)
@@ -486,7 +393,7 @@ def flow_lint(
 @app.command("list")
 def flow_list(
     roles: List[FlowRoleAllNames] = typer.Option(
-        [FlowRole.flow_owner.value],
+        [FlowRole.flow_owner],
         "--role",
         "-r",
         help=(
@@ -515,7 +422,7 @@ def flow_list(
         min=1,
         max=50,
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    flows_endpoint: str = flows_env_var_option,
     filters: Optional[List[str]] = typer.Option(
         None,
         "--filter",
@@ -536,12 +443,19 @@ def flow_list(
         "will further sort ties. [repeatable]",
     ),
     verbose: bool = verbosity_option,
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
+    output_format: ListingOutputFormat = typer.Option(
+        ListingOutputFormat.table,
         "--format",
         "-f",
         help="Output display format.",
         case_sensitive=False,
+        show_default=True,
+    ),
+    watch: bool = typer.Option(
+        False,
+        "--watch",
+        "-w",
+        help="Continuously poll for new Flows.",
         show_default=True,
     ),
 ):
@@ -550,21 +464,25 @@ def flow_list(
     """
     parsed_filters = parse_query_options(filters)
     parsed_orderings = parse_query_options(orderings)
+    role_param = make_role_param(roles)
 
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
-    try:
-        role_param = _make_role_param(roles)
-        response = fc.list_flows(
-            marker=marker,
-            per_page=per_page,
-            filters=parsed_filters,
-            orderings=parsed_orderings,
-            **role_param,
-        )
-    except GlobusAPIError as err:
-        response = err
-
-    format_and_echo(response, output_format.get_dumper(), verbose=verbose)
+    method = functools.partial(
+        fc.list_flows,
+        marker=marker,
+        per_page=per_page,
+        filters=parsed_filters,
+        orderings=parsed_orderings,
+        **role_param,
+    )
+    with live_content:
+        RequestRunner(
+            method,
+            format=output_format,
+            verbose=verbose,
+            watch=watch,
+            fields=FlowListDisplayFields,
+        ).run_and_render()
 
 
 @app.command("display")
@@ -579,25 +497,15 @@ def flow_display(
         callback=input_validator,
         show_default=False,
     ),
-    definition_only: bool = typer.Option(
-        False,
-        "--definition-only",
-        help=(
-            "If present, only the steps of the Flow will be displayed when flow_id "
-            "is provided. Otherwise all fields related to the flow will be "
-            "displayed in the specified output format."
-        ),
-    ),
-    output_format: FlowDisplayFormat = typer.Option(
-        FlowDisplayFormat.json,
+    output_format: ImageOutputFormat = typer.Option(
+        ImageOutputFormat.json,
         "--format",
         "-f",
         help="Output display format.",
         case_sensitive=False,
         show_default=True,
     ),
-    flows_endpoint: str = _flows_env_var_option,
-    verbose: bool = verbosity_option,
+    flows_endpoint: str = flows_env_var_option,
 ):
     """
     Visualize a local or deployed Flow defintion. If providing a Flows's ID, You
@@ -611,46 +519,59 @@ def flow_display(
             "Only one of FLOW_ID or --flow_definition should be set."
         )
 
-    if flow_id:
-        fc = create_flows_client(CLIENT_ID, flows_endpoint)
-        try:
-            flow_get = fc.get_flow(flow_id)
-        except GlobusAPIError as err:
-            format_and_echo(err, verbose=verbose)
-            raise typer.Exit(1)
-        flow_definition = flow_get.data
-        if definition_only:
-            flow_definition = flow_definition["definition"]
-    else:
-        flow_definition = json.loads(flow_definition)
+    fc = create_flows_client(CLIENT_ID, flows_endpoint)
+    rr = RequestRunner(
+        functools.partial(fc.get_flow, flow_id),
+        format=output_format,
+        verbose=False,
+        watch=False,
+    )
 
-    _format_and_display_flow(flow_definition, output_format, verbose=verbose)
+    if flow_id:
+        result = rr.run()
+        if result.is_api_error:
+            rr.format = (
+                output_format
+                if output_format in {ImageOutputFormat.json, ImageOutputFormat.yaml}
+                else ImageOutputFormat.json
+            )
+            rr.render(result)
+            raise typer.Exit(1)
+        else:
+            flow_dict = result.data["definition"]
+    else:
+        flow_dict = process_input(flow_definition)
+
+    if output_format in {ImageOutputFormat.json, ImageOutputFormat.yaml}:
+        rr.render_as_result(flow_dict)
+    else:
+        output_format.visualize(flow_dict)
 
 
 @app.command("delete")
 def flow_delete(
     flow_id: str = typer.Argument(...),
-    output_format: FlowDisplayFormat = typer.Option(
-        FlowDisplayFormat.json,
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.json,
         "--format",
         "-f",
         help="Output display format.",
         case_sensitive=False,
         show_default=True,
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
 ):
     """
     Delete a Flow. You must be in the Flow's "flow_administrators" list.
     """
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
-    try:
-        flow_del = fc.delete_flow(flow_id)
-    except GlobusAPIError as err:
-        format_and_echo(err, verbose=verbose)
-    else:
-        _format_and_display_flow(flow_del, output_format, verbose=verbose)
+    method = functools.partial(fc.delete_flow, flow_id)
+    RequestRunner(
+        method,
+        format=output_format,
+        verbose=verbose,
+    ).run_and_render()
 
 
 @app.command("run")
@@ -689,21 +610,13 @@ def flow_run(
     monitor_by: List[str] = typer.Option(
         None, callback=principal_validator, hidden=True
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
-    output_format: FlowDisplayFormat = typer.Option(
-        FlowDisplayFormat.json,
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.json,
         "--format",
         "-f",
         help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
-    input_format: InputFormat = typer.Option(
-        InputFormat.json,
-        "--input",
-        "-i",
-        help="Input format.",
         case_sensitive=False,
         show_default=True,
     ),
@@ -734,7 +647,7 @@ def flow_run(
     You must be in the Flow's "flow_starters" list.
     """
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
-    flow_input_dict = _process_flow_input(flow_input, input_format)
+    flow_input_dict = process_input(flow_input)
     method = functools.partial(
         fc.run_flow,
         flow_id,
@@ -747,17 +660,27 @@ def flow_run(
         monitor_by=monitor_by,
         manage_by=manage_by,
     )
-
     with live_content:
-        # Set watch to false here to immediately return after running the Action
-        response = request_runner(method, output_format, verbose, False)
+        result = RequestRunner(
+            method,
+            format=output_format,
+            verbose=verbose,
+            watch=watch,
+            run_once=True,
+        ).run_and_render()
 
-        if watch and isinstance(response, GlobusHTTPResponse):
-            action_id = response.data.get("action_id")
+        if not result.is_api_error and watch:
+            action_id = result.data.get("action_id")
             method = functools.partial(
                 fc.flow_action_status, flow_id, flow_scope, action_id
             )
-            request_runner(method, output_format, verbose, watch)
+            RequestRunner(
+                method,
+                format=output_format,
+                verbose=verbose,
+                watch=watch,
+                run_once=False,
+            ).run_and_render()
 
 
 @app.command("action-list")
@@ -786,7 +709,7 @@ def flow_actions_list(
         ),
     ),
     statuses: List[ActionStatus] = typer.Option(
-        None,
+        [],
         "--status",
         help="Display Actions with the selected status. [repeatable]",
     ),
@@ -823,38 +746,52 @@ def flow_actions_list(
         "ordering criteria will be used to sort the data, subsequent ordering criteria "
         "will further sort ties. [repeatable]",
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
+    watch: bool = typer.Option(
+        False,
+        "--watch",
+        "-w",
+        help="Continuously poll for new Actions.",
+        show_default=True,
+    ),
+    output_format: ListingOutputFormat = typer.Option(
+        ListingOutputFormat.table,
+        "--format",
+        "-f",
+        help="Output display format.",
+        case_sensitive=False,
+        show_default=True,
+    ),
 ):
     """
     List a Flow definition's discrete invocations.
     """
     parsed_filters = parse_query_options(filters)
     parsed_orderings = parse_query_options(orderings)
+    statuses_str = [s.value for s in statuses]
+    role_param = make_role_param(roles)
+
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
-
-    # This None check and check makes me unhappy but is necessary for mypy to
-    # be happy with the enums. If we can figure out what defaults flows uses
-    # for flow role/status queries, we can set those here and be done
-    statuses_str = None
-    if statuses is not None:
-        statuses_str = [s.value for s in statuses]
-    role_param = _make_role_param(roles)
-
-    try:
-        result = fc.list_flow_actions(
-            flow_id=flow_id,
-            flow_scope=flow_scope,
-            statuses=statuses_str,
-            marker=marker,
-            per_page=per_page,
-            filters=parsed_filters,
-            orderings=parsed_orderings,
-            **role_param,
-        )
-    except GlobusAPIError as err:
-        result = err
-    format_and_echo(result, verbose=verbose)
+    callable = functools.partial(
+        fc.list_flow_actions,
+        flow_id=flow_id,
+        flow_scope=flow_scope,
+        statuses=statuses_str,
+        marker=marker,
+        per_page=per_page,
+        filters=parsed_filters,
+        orderings=parsed_orderings,
+        **role_param,
+    )
+    with live_content:
+        RequestRunner(
+            callable,
+            format=output_format,
+            verbose=verbose,
+            watch=watch,
+            fields=RunListDisplayFields,
+        ).run_and_render()
 
 
 @app.command("action-status")
@@ -870,12 +807,20 @@ def flow_action_status(
         help="The scope this Flow uses to authenticate requests.",
         callback=url_validator_callback,
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    flows_endpoint: str = flows_env_var_option,
     watch: bool = typer.Option(
         False,
         "--watch",
         "-w",
         help="Continuously poll this Action until it reaches a completed state.",
+        show_default=True,
+    ),
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.json,
+        "--format",
+        "-f",
+        help="Output display format.",
+        case_sensitive=False,
         show_default=True,
     ),
     verbose: bool = verbosity_option,
@@ -885,9 +830,10 @@ def flow_action_status(
     """
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
     method = functools.partial(fc.flow_action_status, flow_id, flow_scope, action_id)
-
     with live_content:
-        request_runner(method, OutputFormat.json, verbose, watch)
+        RequestRunner(
+            method, format=output_format, verbose=verbose, watch=watch
+        ).run_and_render()
 
 
 @app.command("action-resume")
@@ -911,7 +857,22 @@ def flow_action_resume(
             "resume, and prompt for additional consent if needed."
         ),
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    flows_endpoint: str = flows_env_var_option,
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.json,
+        "--format",
+        "-f",
+        help="Output display format.",
+        case_sensitive=False,
+        show_default=True,
+    ),
+    watch: bool = typer.Option(
+        False,
+        "--watch",
+        "-w",
+        help="Continuously poll this Action until it reaches a completed state.",
+        show_default=True,
+    ),
     verbose: bool = verbosity_option,
 ):
     """Resume a Flow in the INACTIVE state. If query-for-inactive-reason is set, and the
@@ -920,19 +881,39 @@ def flow_action_resume(
     Auth web interface.
     """
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
-    try:
-        if query_for_inactive_reason:
-            result = fc.flow_action_status(flow_id, flow_scope, action_id)
+    if query_for_inactive_reason:
+        result = RequestRunner(
+            functools.partial(fc.flow_action_status, flow_id, flow_scope, action_id),
+            format=output_format,
+            verbose=verbose,
+            watch=watch,
+            run_once=True,
+        ).run_and_render()
+        if not result.is_api_error:
             body = result.data
             status = body.get("status")
             details = body.get("details", {})
             code = details.get("code")
             if status == "INACTIVE" and code == "ConsentRequired":
                 flow_scope = details.get("required_scope")
-        result = fc.flow_action_resume(flow_id, flow_scope, action_id)
-    except GlobusAPIError as err:
-        result = err
-    format_and_echo(result, verbose=verbose)
+
+    with live_content:
+        result = RequestRunner(
+            functools.partial(fc.flow_action_resume, flow_id, flow_scope, action_id),
+            format=output_format,
+            verbose=verbose,
+            watch=watch,
+            run_once=True,
+        ).run_and_render()
+        if not result.is_api_error and watch:
+            RequestRunner(
+                functools.partial(
+                    fc.flow_action_status, flow_id, flow_scope, action_id
+                ),
+                format=output_format,
+                verbose=verbose,
+                watch=watch,
+            ).run_and_render()
 
 
 @app.command("action-release")
@@ -949,7 +930,15 @@ def flow_action_release(
         help="The scope this Flow uses to authenticate requests.",
         callback=url_validator_callback,
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.json,
+        "--format",
+        "-f",
+        help="Output display format.",
+        case_sensitive=False,
+        show_default=True,
+    ),
+    flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
 ):
     """
@@ -957,11 +946,10 @@ def flow_action_release(
     After this, no further information about the run can be accessed.
     """
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
-    try:
-        result = fc.flow_action_release(flow_id, flow_scope, action_id)
-    except GlobusAPIError as err:
-        result = err
-    format_and_echo(result, verbose=verbose)
+    method = functools.partial(fc.flow_action_release, flow_id, flow_scope, action_id)
+    RequestRunner(
+        method, format=output_format, verbose=verbose, watch=False
+    ).run_and_render()
 
 
 @app.command("action-cancel")
@@ -978,18 +966,25 @@ def flow_action_cancel(
         help="The scope this Flow uses to authenticate requests.",
         callback=url_validator_callback,
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.json,
+        "--format",
+        "-f",
+        help="Output display format.",
+        case_sensitive=False,
+        show_default=True,
+    ),
+    flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
 ):
     """
     Cancel an active execution for a particular Flow definition's invocation.
     """
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
-    try:
-        result = fc.flow_action_cancel(flow_id, flow_scope, action_id)
-    except GlobusAPIError as err:
-        result = err
-    format_and_echo(result, verbose=verbose)
+    method = functools.partial(fc.flow_action_cancel, flow_id, flow_scope, action_id)
+    RequestRunner(
+        method, format=output_format, verbose=verbose, watch=False
+    ).run_and_render()
 
 
 @app.command("action-log")
@@ -1032,8 +1027,8 @@ def flow_action_log(
         min=1,
         max=50,
     ),
-    output_format: FlowDisplayFormat = typer.Option(
-        FlowDisplayFormat.json,
+    output_format: RunLogOutputFormat = typer.Option(
+        RunLogOutputFormat.table,
         "--format",
         "-f",
         help="Output display format.",
@@ -1049,7 +1044,7 @@ def flow_action_log(
         "Only JSON and YAML output formats are supported.",
         show_default=True,
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
 ):
     """
@@ -1066,33 +1061,36 @@ def flow_action_log(
         marker,
         per_page,
     )
-
-    if watch and output_format in {FlowDisplayFormat.json, FlowDisplayFormat.yaml}:
-        with live_content:
-            flow_log_runner(method, output_format, verbose, watch)
-        raise typer.Exit()
-
-    try:
-        resp = method()
-    except GlobusAPIError as err:
-        resp = err
-
-    if output_format in {FlowDisplayFormat.json, FlowDisplayFormat.yaml}:
-        format_and_echo(resp, output_format.get_dumper(), verbose=verbose)
-    else:
-        if isinstance(resp, GlobusHTTPResponse):
-            flow_def = fc.get_flow(flow_id)
-            dumper = output_format.get_dumper()
-            dumper(resp, flow_def)
+    rr = RequestRunner(
+        method,
+        format=output_format,
+        verbose=verbose,
+        watch=watch,
+        fields=RunLogDisplayFields,
+        detetector=LogCompletionDetetector,
+    )
+    with live_content:
+        if output_format in {
+            RunLogOutputFormat.json,
+            RunLogOutputFormat.yaml,
+            RunLogOutputFormat.table,
+        }:
+            rr.run_and_render()
         else:
-            format_and_echo(resp, verbose=verbose)
+            result = rr.run()
+            if not result.is_api_error:
+                flow_def = fc.get_flow(flow_id)
+                output_format.visualize(result.result, flow_def)
+            else:
+                rr.format = RunLogOutputFormat.json
+                rr.render(result)
 
 
 @app.command("action-enumerate")
 @app.command("run-enumerate")
 def flow_action_enumerate(
     roles: List[ActionRoleAllNames] = typer.Option(
-        [ActionRole.run_owner.value],
+        [ActionRole.run_owner],
         "--role",
         help="Display Actions/Runs where you have at least the selected role. "
         "Precedence of roles is: run_monitor, run_manager, run_owner. "
@@ -1102,8 +1100,8 @@ def flow_action_enumerate(
         "are deprecated. [repeatable use deprecated as the lowest "
         "precedence value provided will determine the Actions/Runs displayed.]",
     ),
-    statuses: Optional[List[ActionStatus]] = typer.Option(
-        None,
+    statuses: List[ActionStatus] = typer.Option(
+        [],
         "--status",
         help="Display Actions with the selected status. [repeatable]",
     ),
@@ -1140,7 +1138,22 @@ def flow_action_enumerate(
         "ordering criteria will be used to sort the data, subsequent ordering criteria "
         "will further sort ties. [repeatable]",
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    watch: bool = typer.Option(
+        False,
+        "--watch",
+        "-w",
+        help="Continuously poll for new Actions.",
+        show_default=True,
+    ),
+    output_format: ListingOutputFormat = typer.Option(
+        ListingOutputFormat.table,
+        "--format",
+        "-f",
+        help="Output display format.",
+        case_sensitive=False,
+        show_default=True,
+    ),
+    flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
 ):
     """
@@ -1148,24 +1161,26 @@ def flow_action_enumerate(
     """
     parsed_filters = parse_query_options(filters)
     parsed_orderings = parse_query_options(orderings)
-    if statuses:
-        statuses_str: Optional[List[str]] = [s.value for s in statuses]
-    else:
-        statuses_str = None
-    role_param = _make_role_param(roles)
+    statuses_str = [s.value for s in statuses]
+    role_param = make_role_param(roles)
     fc = create_flows_client(CLIENT_ID, flows_endpoint, RUN_STATUS_SCOPE)
-    try:
-        resp = fc.enumerate_actions(
-            statuses=statuses_str,
-            marker=marker,
-            per_page=per_page,
-            filters=parsed_filters,
-            orderings=parsed_orderings,
-            **role_param,
-        )
-    except GlobusAPIError as err:
-        resp = err
-    format_and_echo(resp, verbose=verbose)
+    method = functools.partial(
+        fc.enumerate_actions,
+        statuses=statuses_str,
+        marker=marker,
+        per_page=per_page,
+        filters=parsed_filters,
+        orderings=parsed_orderings,
+        **role_param,
+    )
+    with live_content:
+        RequestRunner(
+            method,
+            format=output_format,
+            verbose=verbose,
+            watch=watch,
+            fields=RunEnumerateDisplayFields,
+        ).run_and_render()
 
 
 @app.command("action-update")
@@ -1186,10 +1201,10 @@ def flow_action_update(
         + " [repeatable]",
         callback=principal_validator,
     ),
-    flows_endpoint: str = _flows_env_var_option,
+    flows_endpoint: str = flows_env_var_option,
     verbose: bool = verbosity_option,
-    output_format: FlowDisplayFormat = typer.Option(
-        FlowDisplayFormat.json,
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.json,
         "--format",
         "-f",
         help="Output display format.",
@@ -1203,36 +1218,16 @@ def flow_action_update(
     run_manager = run_manager if run_manager else None
     run_monitor = run_monitor if run_monitor else None
     fc = create_flows_client(CLIENT_ID, flows_endpoint, RUN_STATUS_SCOPE)
-    try:
-        resp = fc.flow_action_update(
+    RequestRunner(
+        functools.partial(
+            fc.flow_action_update,
             action_id,
             run_managers=run_manager,
             run_monitors=run_monitor,
-        )
-    except GlobusAPIError as err:
-        resp = err
-    format_and_echo(resp, dumper=output_format.get_dumper(), verbose=verbose)
-
-
-def _format_and_display_flow(
-    flow_resp: Union[GlobusHTTPResponse, dict],
-    output_format: FlowDisplayFormat,
-    verbose=False,
-):
-    """
-    Diplays a flow as either JSON, graphviz, or an image
-    """
-    if output_format in (FlowDisplayFormat.json, FlowDisplayFormat.yaml):
-        format_and_echo(flow_resp, output_format.get_dumper())
-    elif output_format in (FlowDisplayFormat.graphviz, FlowDisplayFormat.image):
-        if isinstance(flow_resp, GlobusHTTPResponse):
-            flow_resp = flow_resp.data["definition"]
-
-        graphviz_out = graphviz_format(flow_resp)
-        if output_format == FlowDisplayFormat.graphviz:
-            typer.echo(graphviz_out.source)
-        else:
-            graphviz_out.render("flows-output/graph", view=True, cleanup=True)
+        ),
+        format=output_format,
+        verbose=verbose,
+    ).run_and_render()
 
 
 if __name__ == "__main__":

--- a/globus_automate_client/cli/helpers.py
+++ b/globus_automate_client/cli/helpers.py
@@ -6,7 +6,11 @@ import yaml
 from globus_sdk import GlobusAPIError, GlobusHTTPResponse
 
 from globus_automate_client.cli.callbacks import flows_endpoint_envvar_callback
-from globus_automate_client.cli.constants import ActionRoleAllNames, FlowRoleAllNames
+from globus_automate_client.cli.constants import (
+    ActionRoleAllNames,
+    FlowRoleAllNames,
+    OutputFormat,
+)
 
 GlobusCallable = Callable[[], GlobusHTTPResponse]
 GlobusAPIResponse = Union[GlobusAPIError, GlobusHTTPResponse]
@@ -19,6 +23,15 @@ flows_env_var_option = typer.Option(
     None,
     hidden=True,
     callback=flows_endpoint_envvar_callback,
+)
+
+output_format_option: OutputFormat = typer.Option(
+    OutputFormat.json,
+    "--format",
+    "-f",
+    help="Output display format.",
+    case_sensitive=False,
+    show_default=True,
 )
 
 

--- a/globus_automate_client/cli/helpers.py
+++ b/globus_automate_client/cli/helpers.py
@@ -1,14 +1,12 @@
 import json
-import time
 from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
 import typer
 import yaml
 from globus_sdk import GlobusAPIError, GlobusHTTPResponse
-from rich.text import Text
 
-from globus_automate_client.cli.constants import InputFormat, OutputFormat
-from globus_automate_client.cli.rich_rendering import cli_content
+from globus_automate_client.cli.callbacks import flows_endpoint_envvar_callback
+from globus_automate_client.cli.constants import ActionRoleAllNames, FlowRoleAllNames
 
 GlobusCallable = Callable[[], GlobusHTTPResponse]
 GlobusAPIResponse = Union[GlobusAPIError, GlobusHTTPResponse]
@@ -17,144 +15,11 @@ verbosity_option = typer.Option(
     False, "--verbose", "-v", help="Run with increased verbosity", show_default=False
 )
 
-
-def get_renderable_response(
-    result: Union[GlobusHTTPResponse, str, GlobusAPIError],
-    dumper: Callable = OutputFormat.json.get_dumper(),
-    verbose: bool = False,
-) -> Text:
-    text = Text()
-
-    if verbose:
-        verbose_output = get_http_details(result)
-        text.append(f"{verbose_output}\n\n", style="bright_cyan")
-
-    if isinstance(result, GlobusHTTPResponse):
-        result = result.data
-        style = "green"
-    elif isinstance(result, GlobusAPIError):
-        result = result.raw_json if result.raw_json else result.raw_text
-        style = "red"
-    else:
-        result = result
-
-    text.append(dumper(result), style=style)
-    return text
-
-
-def request_runner(
-    operation: GlobusCallable, output_format, verbose: bool, follow: bool
-) -> GlobusAPIResponse:
-    """
-    This function takes an operation and executes it until it returns a
-    completed Action state or a GlobusAPIError. On each execution, it will
-    display the results of the query while keeping track of how much output was
-    produced. Using this information, it will clear the previous number of lines
-    from stdout before displaying updated results.
-    """
-    dumper = output_format.get_dumper()
-    terminal_statuses = {"SUCCEEDED", "FAILED"}
-    cli_content.init()
-
-    while True:
-        if cli_content.time_to_update():
-            try:
-                result = operation()
-            except GlobusAPIError as err:
-                result = err
-
-            text = get_renderable_response(result, dumper, verbose)
-            cli_content.update(text)
-            if (
-                not follow
-                or isinstance(result, GlobusAPIError)
-                or result.data["status"] in terminal_statuses
-            ):
-                break
-        else:
-            time.sleep(1)
-
-    cli_content.complete()
-    return result
-
-
-# TODO Any way to refactor this?
-def flow_log_runner(
-    operation: GlobusCallable, output_format, verbose: bool, follow: bool
-) -> GlobusAPIResponse:
-    dumper = output_format.get_dumper()
-    terminal_statuses = {"FlowSucceeded", "FlowFailed", "FlowCanceled"}
-    cli_content.init()
-
-    while True:
-        if cli_content.time_to_update():
-            try:
-                result = operation()
-            except GlobusAPIError as err:
-                result = err
-
-            text = get_flow_renderable_response(result, dumper, verbose)
-            cli_content.update(text)
-            if (
-                not follow
-                or isinstance(result, GlobusAPIError)
-                or result.data["entries"][-1]["code"] in terminal_statuses
-            ):
-                break
-        else:
-            time.sleep(1)
-
-    cli_content.complete()
-    return result
-
-
-def get_flow_renderable_response(
-    result: Union[GlobusHTTPResponse, str, GlobusAPIError],
-    dumper: Callable = OutputFormat.json.get_dumper(),
-    verbose: bool = False,
-) -> Text:
-    text = Text()
-
-    if verbose:
-        verbose_output = get_http_details(result)
-        text.append(f"{verbose_output}\n\n", style="bright_cyan")
-
-    if isinstance(result, GlobusHTTPResponse):
-        result = result.data["entries"][-1]
-        style = "green"
-    elif isinstance(result, GlobusAPIError):
-        result = result.raw_json if result.raw_json else result.raw_text
-        style = "red"
-    else:
-        result = result
-
-    text.append(dumper(result), style=style)
-    return text
-
-
-def format_and_echo(
-    result: Union[GlobusHTTPResponse, str, GlobusAPIError],
-    dumper: Callable = OutputFormat.json.get_dumper(),
-    verbose=False,
-):
-    if verbose:
-        typer.secho(
-            f"{get_http_details(result)}\n", fg=typer.colors.BRIGHT_CYAN, err=True
-        )
-
-    if isinstance(result, GlobusHTTPResponse):
-        if 200 <= result.http_status < 300:
-            color = typer.colors.GREEN
-        else:
-            color = typer.colors.RED
-        result = result.data
-    elif isinstance(result, GlobusAPIError):
-        color = typer.colors.RED
-        result = result.raw_json if result.raw_json else result.raw_text
-    else:
-        color = typer.colors.GREEN
-
-    typer.secho(dumper(result), fg=color)
+flows_env_var_option = typer.Option(
+    None,
+    hidden=True,
+    callback=flows_endpoint_envvar_callback,
+)
 
 
 def get_http_details(result: Union[GlobusHTTPResponse, GlobusAPIError]) -> str:
@@ -176,27 +41,20 @@ def get_http_details(result: Union[GlobusHTTPResponse, GlobusAPIError]) -> str:
     return http_details
 
 
-def process_input(
-    input_arg: Union[str, None], input_format: InputFormat, error_explanation: str = ""
-) -> Optional[Mapping[str, Any]]:
+def process_input(input_arg: Optional[str]) -> Optional[Mapping[str, Any]]:
     """
-    Turn input strings into dicts per input format type (InputFormat)
+    Turn input strings into dicts
     """
-
     if input_arg is None:
         return None
 
-    input_dict = None
-    if input_format is InputFormat.json:
-        try:
-            input_dict = json.loads(input_arg)
-        except json.JSONDecodeError as e:
-            raise typer.BadParameter(f"Invalid JSON{error_explanation}: {e}")
-    elif input_format is InputFormat.yaml:
+    try:
+        input_dict = json.loads(input_arg)
+    except json.JSONDecodeError:
         try:
             input_dict = yaml.safe_load(input_arg)
-        except Exception as e:
-            raise typer.BadParameter(f"Invalid YAML{error_explanation}: {e}")
+        except yaml.YAMLError:
+            raise typer.BadParameter(f"Unable to load input as JSON or YAML")
 
     return input_dict
 
@@ -218,3 +76,19 @@ def parse_query_options(queries: Optional[List[str]]) -> Dict[str, str]:
             raise typer.BadParameter(f"Issue parsing '{q}'. Missing pattern.")
         result[field] = pattern
     return result
+
+
+def make_role_param(
+    roles_list: Optional[Union[List[FlowRoleAllNames], List[ActionRoleAllNames]]]
+) -> Mapping[str, Any]:
+    if roles_list is None or len(roles_list) == 0:
+        return {"role": None}
+    elif len(roles_list) == 1:
+        return {"role": roles_list[0].value}
+    else:
+        typer.secho(
+            "Warning: Use of multiple --role options is deprecated",
+            err=True,
+            fg=typer.colors.YELLOW,
+        )
+        return {"roles": [r.value for r in roles_list]}

--- a/globus_automate_client/cli/main.py
+++ b/globus_automate_client/cli/main.py
@@ -1,5 +1,3 @@
-import sys
-
 import typer
 import yaml
 

--- a/globus_automate_client/cli/queues.py
+++ b/globus_automate_client/cli/queues.py
@@ -7,7 +7,7 @@ import typer
 from globus_automate_client.cli.auth import CLIENT_ID
 from globus_automate_client.cli.callbacks import input_validator, principal_validator
 from globus_automate_client.cli.constants import OutputFormat
-from globus_automate_client.cli.helpers import verbosity_option
+from globus_automate_client.cli.helpers import output_format_option, verbosity_option
 from globus_automate_client.cli.rich_helpers import RequestRunner
 from globus_automate_client.queues_client import create_queues_client
 
@@ -31,14 +31,7 @@ def queue_list(
         case_sensitive=False,
         show_default=True,
     ),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     verbose: bool = verbosity_option,
 ):
     """
@@ -87,14 +80,7 @@ def queue_create(
         max=1209600,
         show_default=True,
     ),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     verbose: bool = verbosity_option,
 ):
     """
@@ -148,14 +134,7 @@ def queue_update(
         min=1,
         max=43200,
     ),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     verbose: bool = verbosity_option,
 ):
     """
@@ -178,14 +157,7 @@ def queue_update(
 @app.command("display")
 def queue_display(
     queue_id: str = typer.Argument(...),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     verbose: bool = verbosity_option,
 ):
     """
@@ -200,14 +172,7 @@ def queue_display(
 @app.command("delete")
 def queue_delete(
     queue_id: str = typer.Argument(...),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     verbose: bool = verbosity_option,
 ):
     """
@@ -228,14 +193,7 @@ def queue_receive(
     max_messages: int = typer.Option(
         None, help="The maximum number of messages to retrieve from the Queue", min=0
     ),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     verbose: bool = verbosity_option,
 ):
     """
@@ -261,14 +219,7 @@ def queue_send(
         prompt=True,
         callback=input_validator,
     ),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     verbose: bool = verbosity_option,
 ):
     """
@@ -293,14 +244,7 @@ def queue_delete_message(
             "receive message. [repeatable]"
         ),
     ),
-    output_format: OutputFormat = typer.Option(
-        OutputFormat.json,
-        "--format",
-        "-f",
-        help="Output display format.",
-        case_sensitive=False,
-        show_default=True,
-    ),
+    output_format: OutputFormat = output_format_option,
     verbose: bool = verbosity_option,
 ):
     """

--- a/globus_automate_client/cli/rich_helpers.py
+++ b/globus_automate_client/cli/rich_helpers.py
@@ -222,19 +222,16 @@ class Result:
     def __init__(
         self,
         response: Union[GlobusHTTPResponse, GlobusAPIError, str],
-        detetector: Optional[Type[CompletionDetetector]] = None,
+        detetector: Type[CompletionDetetector] = ActionCompletionDetector,
     ):
         self.result = response
-        if detetector is None:
-            self.detetector: Type[CompletionDetetector] = ActionCompletionDetector
-        else:
-            self.detetector = detetector
+        self.detetector = detetector
 
         self.is_api_error = isinstance(response, GlobusAPIError)
         self.data: Dict[str, Any]
         if isinstance(response, str):
             self.data = {"result": response}
-        elif isinstance(response, GlobusAPIError):
+        elif self.is_api_error:
             self.data = response.raw_json if response.raw_json else response.raw_text
         else:
             self.data = response.data
@@ -390,7 +387,7 @@ class RequestRunner:
         watch: bool = False,
         run_once: bool = False,
         fields: Optional[Type[DisplayFields]] = None,
-        detetector: Optional[Type[CompletionDetetector]] = None,
+        detetector: Type[CompletionDetetector] = ActionCompletionDetector,
     ):
         self.callable = callable
         self.format = format

--- a/globus_automate_client/cli/rich_helpers.py
+++ b/globus_automate_client/cli/rich_helpers.py
@@ -1,0 +1,392 @@
+import abc
+import json
+from time import sleep
+from typing import Any, Callable, Dict, List, Optional, Set, Type, Union
+
+import arrow
+import typer
+import yaml
+from globus_sdk import GlobusAPIError, GlobusHTTPResponse
+from requests import Response
+from rich.console import RenderableType, RenderGroup
+from rich.spinner import Spinner
+from rich.table import Table
+from rich.text import Text
+from typing_extensions import Literal
+
+from .constants import OutputFormat
+from .helpers import get_http_details
+from .rich_rendering import cli_content
+
+
+def humanize_datetimes(dt: str) -> str:
+    return arrow.get(dt).humanize()
+
+
+def humanize_auth_urn(urn: str) -> str:
+    id = urn.split(":")[-1]
+    if urn.startswith("urn:globus:auth:identity:"):
+        return f"User: {id}"
+    elif urn.startswith("urn:globus:groups:id:"):
+        return f"Group: {id}"
+    return urn
+
+
+class Field:
+    """
+    A generic class structure for transforming lists of data into a table. Each
+    instance of this class represents a single field to pull from a data item.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        default: str,
+        transformation: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        """
+        name: The name of the field which contains the data for display
+        default: A placeholder to use if the field is not available
+        transformation: A callable that takes and returns a string. This is used
+            to format the data field
+        """
+        self.name = name
+        self.default = default
+        self.transformation = transformation
+
+
+class DisplayFields(abc.ABC):
+    """
+    An object representing how to parse lists of data into a table.
+
+    fields: A list of Fields that defines which fields get rendered into a table
+        and how they are presented
+    path_to_data_list: A key under which the data list is defined
+    """
+
+    fields: List[Field]
+    path_to_data_list: str
+
+
+class RunListDisplayFields(DisplayFields):
+    """
+    This object defines the fields and display style of a Run listing into a
+    table.
+    """
+
+    fields = [
+        Field("action_id", ""),
+        Field("label", "<EMPTY>"),
+        Field("status", ""),
+        Field("start_time", "", humanize_datetimes),
+        Field("created_by", "", humanize_auth_urn),
+        Field("flow_id", "<DELETED>"),
+    ]
+    path_to_data_list = "actions"
+
+
+class RunEnumerateDisplayFields(RunListDisplayFields):
+    """
+    This object defines the fields and display style of a Run enumeration into a
+    table.
+    """
+
+    path_to_data_list = "runs"
+
+
+class FlowListDisplayFields(DisplayFields):
+    """
+    This object defines the fields and display style of a Flow listing into a
+    table.
+    """
+
+    fields = [
+        Field("title", ""),
+        Field("id", ""),
+        Field("flow_owner", "", humanize_auth_urn),
+        Field("created_at", "", humanize_datetimes),
+        Field("updated_at", "", humanize_datetimes),
+    ]
+    path_to_data_list = "flows"
+
+
+class RunLogDisplayFields(DisplayFields):
+    """
+    This object defines the fields and display style of a Run log listing into a
+    table.
+    """
+
+    fields = [
+        Field("code", ""),
+        Field("description", ""),
+        Field("time", "", humanize_datetimes),
+    ]
+    path_to_data_list = "entries"
+
+
+class CompletionDetetector(abc.ABC):
+    """
+    An object that can be used to determine if an operation is complete or if it
+    should continue polling.
+    """
+
+    terminals: Set[str]
+
+    @classmethod
+    @abc.abstractmethod
+    def is_complete(self, result: Union[GlobusHTTPResponse, GlobusAPIError]) -> bool:
+        """
+        Given either a GloubsHTTPReponse or GlobusAPIError, this method should
+        return a boolean indicating if polling should continue.
+        """
+        pass
+
+
+class ActionCompletionDetector(CompletionDetetector):
+    """
+    This class determines when a Run has reached a completed state.
+    """
+
+    terminals: Set[str] = {"SUCCEEDED", "FAILED"}
+
+    @classmethod
+    def is_complete(self, result: Union[GlobusHTTPResponse, GlobusAPIError]) -> bool:
+        return (
+            isinstance(result, GlobusAPIError)
+            or result.data.get("status", None) in self.terminals
+        )
+
+
+class LogCompletionDetetector(CompletionDetetector):
+    """
+    This class determines when a Run has reached a completed state from
+    inspecting its logs.
+    """
+
+    terminals: Set[str] = {"FlowSucceeded", "FlowFailed", "FlowCanceled"}
+
+    @classmethod
+    def is_complete(self, result: Union[GlobusHTTPResponse, GlobusAPIError]) -> bool:
+        return (
+            isinstance(result, GlobusAPIError)
+            or result.data["entries"][-1]["code"] in self.terminals
+        )
+
+
+class Result:
+    """
+    A class which wraps a Globus API response.
+    """
+
+    def __init__(
+        self,
+        response: Union[GlobusHTTPResponse, GlobusAPIError, str],
+        detetector: Optional[Type[CompletionDetetector]] = None,
+    ):
+        self.result = response
+        if detetector is None:
+            self.detetector: Type[CompletionDetetector] = ActionCompletionDetector
+        else:
+            self.detetector = detetector
+
+        self.is_api_error = isinstance(response, GlobusAPIError)
+        self.data: Dict[str, Any]
+        if isinstance(response, str):
+            self.data = {"result": response}
+        elif isinstance(response, GlobusAPIError):
+            self.data = response.raw_json if response.raw_json else response.raw_text
+        else:
+            self.data = response.data
+
+    @property
+    def details(self) -> str:
+        return get_http_details(self.result)
+
+    @property
+    def completed(self) -> bool:
+        return self.detetector.is_complete(self.result)
+
+    def as_json(self) -> str:
+        return json.dumps(self.data, indent=2).strip()
+
+    def as_yaml(self) -> str:
+        return yaml.dump(self.data, indent=2).strip()
+
+
+class Renderer:
+    """
+    A class which understands how to render itself as json, yaml or a table and
+    under which cirsumstances to use rich rendering. It's important that not
+    every output be rendered using rich because JSON parsing tools cannot parse
+    rich objects.
+    """
+
+    def __init__(
+        self,
+        result: Result,
+        *,
+        verbose: bool = False,
+        watching: bool = False,
+        format: Literal["json", "yaml", "table"] = "json",
+        fields: Optional[Type[DisplayFields]] = None,
+        run_once: bool = False,
+    ):
+        self.result = result
+        self.verbose = verbose
+        self.watching = watching
+        self.run_once = run_once
+        self.format = format
+        self.fields = fields
+        self.table_style = "orange1"
+        self.detail_style = "cyan"
+        self.success_style = "green"
+        self.fail_style = "red"
+        self.spinner = Spinner("simpleDotsScrolling")
+
+        if format == "table":
+            assert fields is not None
+
+    @property
+    def will_update(self) -> bool:
+        return self.watching and not self.result.completed and not self.run_once
+
+    @property
+    def use_rich_rendering(self) -> bool:
+        return self.watching or self.format == "table"
+
+    @property
+    def result_style(self) -> str:
+        if self.result.is_api_error:
+            return self.fail_style
+        return self.success_style
+
+    @property
+    def details_as_text(self) -> Text:
+        return Text(self.result.details, style=self.detail_style)
+
+    @property
+    def details_as_str(self) -> str:
+        return self.details_as_text.plain
+
+    @property
+    def result_as_text(self) -> Text:
+        if self.result.is_api_error:
+            style = self.fail_style
+        else:
+            style = self.success_style
+
+        if self.format == "yaml":
+            return Text(self.result.as_yaml(), style)
+        return Text(self.result.as_json(), style)
+
+    @property
+    def result_as_renderable(self) -> RenderableType:
+        if self.format != "table" or self.result.is_api_error:
+            return self.result_as_text
+
+        assert self.fields is not None
+        table = Table()
+        for f in self.fields.fields:
+            table.add_column(f.name, style=self.table_style)
+
+        list_of_data: List[Dict[str, Any]] = self.result.data[
+            self.fields.path_to_data_list
+        ]
+        for d in list_of_data:
+            row_values = []
+            for f in self.fields.fields:
+                value = d.get(f.name, f.default)
+                if f.transformation:
+                    value = f.transformation(value)
+                row_values.append(value)
+            table.add_row(*row_values)
+        return table
+
+    @property
+    def result_as_str(self) -> str:
+        return self.result_as_text.plain
+
+    def render(self):
+        """
+        Determine how and what to render to the console. If not using rich
+        rendering, all output is handled by typer, allowing outside tools such
+        as JQ to parse the results.
+        """
+        if self.use_rich_rendering:
+            renderables: List[RenderableType] = []
+            if self.verbose:
+                d = self.details_as_text
+                renderables.append(d)
+            r = self.result_as_renderable
+            renderables.append(r)
+            if self.will_update:
+                s = self.spinner
+                renderables.append(s)
+
+            cli_content.rg = RenderGroup(*renderables)
+        else:
+            if self.verbose:
+                typer.secho(self.details_as_str, fg=self.detail_style, err=True)
+            typer.secho(self.result_as_str, fg=self.result_style, nl=True)
+
+
+class RequestRunner:
+    """
+    A utility class for encapsulating logic around repeated requests, error
+    handling, and output formatting. In general, run_and_render should be the
+    interface into instances. But for fine grain control on execution and
+    rendering, the individual methods may be called.
+    """
+
+    def __init__(
+        self,
+        callable: Callable[[], GlobusHTTPResponse],
+        *,
+        format: OutputFormat = OutputFormat.json,
+        verbose: bool = False,
+        watch: bool = False,
+        run_once: bool = False,
+        fields: Optional[Type[DisplayFields]] = None,
+        detetector: Optional[Type[CompletionDetetector]] = None,
+    ):
+        self.callable = callable
+        self.format = format
+        self.verbose = verbose
+        self.watch = watch
+        self.fields = fields
+        self.run_once = run_once
+        self.detetector = detetector
+
+    def run(self) -> Result:
+        try:
+            result = self.callable()
+        except GlobusAPIError as err:
+            result = err
+        return Result(result, detetector=self.detetector)
+
+    def render(self, result: Result):
+        Renderer(
+            result,
+            verbose=self.verbose,
+            watching=self.watch,
+            format=self.format,
+            fields=self.fields,
+            run_once=self.run_once,
+        ).render()
+
+    def render_as_result(self, d: Dict[str, Any], status_code: int = 200):
+        resp = Response()
+        resp.status_code = status_code
+        resp._content = json.dumps(d).encode("utf-8")
+        resp.headers.update({"Content-Type": "application/json"})
+        globus_resp = GlobusHTTPResponse(resp)
+        self.render(Result(globus_resp))
+
+    def run_and_render(self) -> Result:
+        while True:
+            result = self.run()
+            self.render(result)
+            if not self.watch or self.run_once or result.completed:
+                break
+            sleep(2)
+        return result

--- a/globus_automate_client/cli/rich_rendering.py
+++ b/globus_automate_client/cli/rich_rendering.py
@@ -1,77 +1,20 @@
-import time
 from typing import Callable, Optional
 
 from rich.console import RenderGroup
 from rich.live import Live
-from rich.spinner import Spinner
-from rich.text import Text
 
 
-class CLIContent:
+class Content:
     """
-    A rich renderable class that displays CLI content.
-
-    Depending on when the state of this object it will either display nothing
-    (in the case that it was never updated), text only (in the case that its
-    content will stop getting updated), or text and a spinner (in the case that
-    it will periodically receive updated content to display).
-
-    Additionally, this class functions as a counter to indicate when it expects
-    to get its text content updated. This ensures that the renderable is only
-    updated at a fixed interval, instead of on every refresh.
+    This class represents a per CLI invocation "canvas" which will hold the data
+    that gets displayed on the CLI. All content updates happen by updating the
+    value of the instance's RenderGroup
     """
 
-    spinner: Spinner = Spinner("simpleDotsScrolling")
-    last_update: Optional[float] = None
-    text: Text = Text()
-    done = False
+    rg: RenderGroup = RenderGroup()
 
-    def __init__(self, interval: int):
-        self.interval = interval
-
-    def time_to_update(self):
-        """
-        Track how often updates to the CLIContents should be made.
-        """
-        now = time.time()
-        if self.last_update is None or now - self.last_update >= self.interval:
-            return True
-        return False
-
-    def update(self, text: Text):
-        """
-        Update the object's text output. This will cause the CLIContent to begin
-        displaying a spinner indicating updates are incoming.
-        """
-        self.last_update = time.time()
-        self.text = text
-
-    def init(self):
-        """
-        Prepare the object to begin receiving updates.
-        """
-        self.done = False
-
-    def complete(self):
-        """
-        Set the object's state to indicate that it will no longer receive
-        updates.
-        """
-        self.done = True
-
-    def __rich__(self) -> Text:
-        """
-        The dunder method for the rich protocol which gets called on refresh.
-        """
-        # If last_update is None, that means this instance has nothing to
-        # render, so omit the spinner.
-        if self.last_update is None:
-            return self.text
-
-        # If the CLIContent will no longer receive updates, omit the spinner.
-        if self.done:
-            return self.text
-        return RenderGroup(self.text, self.spinner)
+    def __rich__(self) -> RenderGroup:
+        return self.rg
 
 
 class PauseableLive(Live):
@@ -98,5 +41,5 @@ class PauseableLive(Live):
             self._refresh_thread.live.refresh = self.live_refresher
 
 
-cli_content = CLIContent(4)
+cli_content = Content()
 live_content = PauseableLive(cli_content, refresh_per_second=20)

--- a/globus_automate_client/client_helpers.py
+++ b/globus_automate_client/client_helpers.py
@@ -54,9 +54,11 @@ def create_action_client(
         >>> resp = ac.run({"echo_string": "Hello from SDK"})
         >>> assert resp.data["status"] == "SUCCEEDED"
     """
+    live_content.pause_live()
     authorizer = get_cli_authorizer(
         action_url=action_url, action_scope=action_scope, client_id=client_id
     )
+    live_content.resume_live()
     return ActionClient.new_client(action_url=action_url, authorizer=authorizer)
 
 

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -330,7 +330,7 @@ class FlowsClient(BaseClient):
         validate_definition: bool = True,
         validate_schema: bool = True,
         **kwargs,
-    ) -> Optional[GlobusHTTPResponse]:
+    ) -> GlobusHTTPResponse:
         """
         Updates a deployed Flow's definition or metadata. This method will
         preserve the existing Flow's values for fields which are not
@@ -395,10 +395,7 @@ class FlowsClient(BaseClient):
         temp_body["input_schema"] = input_schema
         # Remove None / empty list items from the temp_body
         req_body = {k: v for k, v in temp_body.items() if v}
-        if len(req_body) == 0:
-            return None
-        else:
-            return self.put(f"/flows/{flow_id}", req_body, **kwargs)
+        return self.put(f"/flows/{flow_id}", req_body, **kwargs)
 
     def get_flow(self, flow_id: str, **kwargs) -> GlobusHTTPResponse:
         """
@@ -748,7 +745,9 @@ class FlowsClient(BaseClient):
 
         """
         params = {}
-        if roles:
+        if role:
+            params["filter_role"] = role
+        elif roles:
             params["filter_roles"] = ",".join(roles)
         if statuses:
             params["filter_status"] = ",".join(statuses)

--- a/globus_automate_client/queues_client.py
+++ b/globus_automate_client/queues_client.py
@@ -78,6 +78,7 @@ class QueuesClient(BaseClient):
         senders: Optional[List[str]] = None,
         receivers: Optional[List[str]] = None,
         delivery_timeout: Optional[int] = None,
+        visibility_timeout: Optional[int] = None,
         **kwargs,
     ) -> Optional[GlobusHTTPResponse]:
         body = dict(
@@ -87,6 +88,7 @@ class QueuesClient(BaseClient):
             senders=senders,
             receivers=receivers,
             delivery_timeout=delivery_timeout,
+            visibility_timeout=visibility_timeout,
         )
         # Remove the missing values from the update operation
         body = {k: v for k, v in body.items() if v is not None}

--- a/poetry.lock
+++ b/poetry.lock
@@ -40,6 +40,18 @@ docs = ["sphinx"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest"]
 
 [[package]]
+name = "arrow"
+version = "1.1.1"
+description = "Better dates & times for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+python-dateutil = ">=2.7.0"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
 name = "async-generator"
 version = "1.10"
 description = "Async generators and context managers for Python 3.5+"
@@ -200,7 +212,7 @@ test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "cryptography"
-version = "3.4.7"
+version = "3.4.8"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -528,13 +540,14 @@ qtconsole = "*"
 
 [[package]]
 name = "jupyter-client"
-version = "6.2.0"
+version = "7.0.1"
 description = "Jupyter protocol implementation and client libraries"
 category = "dev"
 optional = false
 python-versions = ">=3.6.1"
 
 [package.dependencies]
+entrypoints = "*"
 jupyter-core = ">=4.6.0"
 nest-asyncio = ">=1.5"
 python-dateutil = ">=2.1"
@@ -543,8 +556,8 @@ tornado = ">=4.1"
 traitlets = "*"
 
 [package.extras]
-doc = ["sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
-test = ["async-generator", "ipykernel", "ipython", "mock", "pytest-asyncio", "pytest-timeout", "pytest", "mypy", "pre-commit", "jedi (<0.18)"]
+doc = ["myst-parser", "sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
+test = ["codecov", "coverage", "ipykernel", "ipython", "mock", "mypy", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov", "pytest-timeout", "jedi (<0.18)"]
 
 [[package]]
 name = "jupyter-console"
@@ -857,11 +870,11 @@ twisted = ["twisted"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.19"
+version = "3.0.20"
 description = "Library for building powerful interactive command lines in Python"
 category = "dev"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.6.2"
 
 [package.dependencies]
 wcwidth = "*"
@@ -981,7 +994,7 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
@@ -1071,15 +1084,15 @@ test = ["flaky", "pytest", "pytest-qt"]
 
 [[package]]
 name = "qtpy"
-version = "1.9.0"
+version = "1.10.0"
 description = "Provides an abstraction layer on top of the various Qt bindings (PyQt5, PyQt4 and PySide) and additional custom QWidgets."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 
 [[package]]
 name = "regex"
-version = "2021.8.3"
+version = "2021.8.21"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -1321,7 +1334,7 @@ test = ["pytest"]
 
 [[package]]
 name = "terminado"
-version = "0.11.0"
+version = "0.11.1"
 description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
 category = "dev"
 optional = false
@@ -1444,6 +1457,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "types-requests"
+version = "2.25.6"
+description = "Typing stubs for requests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -1514,7 +1535,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "ca2204fabe7f8486b24d935103ab84483b84f384a09f76a9c278782faf2faa44"
+content-hash = "683a5e3f37138459cf5a8704ee224f8f0f4691dbdd88c574b0bb05d1d35db96a"
 
 [metadata.files]
 alabaster = [
@@ -1548,6 +1569,10 @@ argon2-cffi = [
     {file = "argon2_cffi-20.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:9dfd5197852530294ecb5795c97a823839258dfd5eb9420233c7cfedec2058f2"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win32.whl", hash = "sha256:e2db6e85c057c16d0bd3b4d2b04f270a7467c147381e8fd73cbbe5bc719832be"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a84934bd818e14a17943de8099d41160da4a336bcc699bb4c394bbb9b94bd32"},
+]
+arrow = [
+    {file = "arrow-1.1.1-py3-none-any.whl", hash = "sha256:77a60a4db5766d900a2085ce9074c5c7b8e2c99afeaa98ad627637ff6f292510"},
+    {file = "arrow-1.1.1.tar.gz", hash = "sha256:dee7602f6c60e3ec510095b5e301441bc56288cb8f51def14dcb3079f623823a"},
 ]
 async-generator = [
     {file = "async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b"},
@@ -1650,18 +1675,23 @@ commonmark = [
     {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
 cryptography = [
-    {file = "cryptography-3.4.7-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1"},
-    {file = "cryptography-3.4.7-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250"},
-    {file = "cryptography-3.4.7-cp36-abi3-manylinux2010_x86_64.whl", hash = "sha256:37340614f8a5d2fb9aeea67fd159bfe4f5f4ed535b1090ce8ec428b2f15a11f2"},
-    {file = "cryptography-3.4.7-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:240f5c21aef0b73f40bb9f78d2caff73186700bf1bc6b94285699aff98cc16c6"},
-    {file = "cryptography-3.4.7-cp36-abi3-manylinux2014_x86_64.whl", hash = "sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959"},
-    {file = "cryptography-3.4.7-cp36-abi3-win32.whl", hash = "sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d"},
-    {file = "cryptography-3.4.7-cp36-abi3-win_amd64.whl", hash = "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca"},
-    {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873"},
-    {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d"},
-    {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177"},
-    {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
-    {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
+    {file = "cryptography-3.4.8-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:a00cf305f07b26c351d8d4e1af84ad7501eca8a342dedf24a7acb0e7b7406e14"},
+    {file = "cryptography-3.4.8-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:f44d141b8c4ea5eb4dbc9b3ad992d45580c1d22bf5e24363f2fbf50c2d7ae8a7"},
+    {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0a7dcbcd3f1913f664aca35d47c1331fce738d44ec34b7be8b9d332151b0b01e"},
+    {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34dae04a0dce5730d8eb7894eab617d8a70d0c97da76b905de9efb7128ad7085"},
+    {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1eb7bb0df6f6f583dd8e054689def236255161ebbcf62b226454ab9ec663746b"},
+    {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:9965c46c674ba8cc572bc09a03f4c649292ee73e1b683adb1ce81e82e9a6a0fb"},
+    {file = "cryptography-3.4.8-cp36-abi3-win32.whl", hash = "sha256:21ca464b3a4b8d8e86ba0ee5045e103a1fcfac3b39319727bc0fc58c09c6aff7"},
+    {file = "cryptography-3.4.8-cp36-abi3-win_amd64.whl", hash = "sha256:3520667fda779eb788ea00080124875be18f2d8f0848ec00733c0ec3bb8219fc"},
+    {file = "cryptography-3.4.8-pp36-pypy36_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d2a6e5ef66503da51d2110edf6c403dc6b494cc0082f85db12f54e9c5d4c3ec5"},
+    {file = "cryptography-3.4.8-pp36-pypy36_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a305600e7a6b7b855cd798e00278161b681ad6e9b7eca94c721d5f588ab212af"},
+    {file = "cryptography-3.4.8-pp36-pypy36_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:3fa3a7ccf96e826affdf1a0a9432be74dc73423125c8f96a909e3835a5ef194a"},
+    {file = "cryptography-3.4.8-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:d9ec0e67a14f9d1d48dd87a2531009a9b251c02ea42851c060b25c782516ff06"},
+    {file = "cryptography-3.4.8-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5b0fbfae7ff7febdb74b574055c7466da334a5371f253732d7e2e7525d570498"},
+    {file = "cryptography-3.4.8-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94fff993ee9bc1b2440d3b7243d488c6a3d9724cc2b09cdb297f6a886d040ef7"},
+    {file = "cryptography-3.4.8-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:8695456444f277af73a4877db9fc979849cd3ee74c198d04fc0776ebc3db52b9"},
+    {file = "cryptography-3.4.8-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:cd65b60cfe004790c795cc35f272e41a3df4631e2fb6b35aa7ac6ef2859d554e"},
+    {file = "cryptography-3.4.8.tar.gz", hash = "sha256:94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c"},
 ]
 css-html-js-minify = [
     {file = "css-html-js-minify-2.5.5.zip", hash = "sha256:4a9f11f7e0496f5284d12111f3ba4ff5ff2023d12f15d195c9c48bd97013746c"},
@@ -1760,8 +1790,8 @@ jupyter = [
     {file = "jupyter-1.0.0.zip", hash = "sha256:3e1f86076bbb7c8c207829390305a2b1fe836d471ed54be66a3b8c41e7f46cc7"},
 ]
 jupyter-client = [
-    {file = "jupyter_client-6.2.0-py3-none-any.whl", hash = "sha256:9715152067e3f7ea3b56f341c9a0f9715c8c7cc316ee0eb13c3c84f5ca0065f5"},
-    {file = "jupyter_client-6.2.0.tar.gz", hash = "sha256:e2ab61d79fbf8b56734a4c2499f19830fbd7f6fefb3e87868ef0545cb3c17eb9"},
+    {file = "jupyter_client-7.0.1-py3-none-any.whl", hash = "sha256:07b9566979546004c089afe7c9bf9e96224ec5f8421fe0ae460759fa593c6b1d"},
+    {file = "jupyter_client-7.0.1.tar.gz", hash = "sha256:48822a93d9d75daa5fde235c35cf7a92fc979384735962501d4eb60b197fb43a"},
 ]
 jupyter-console = [
     {file = "jupyter_console-6.4.0-py3-none-any.whl", hash = "sha256:7799c4ea951e0e96ba8260575423cb323ea5a03fcf5503560fa3e15748869e27"},
@@ -1946,8 +1976,8 @@ prometheus-client = [
     {file = "prometheus_client-0.11.0.tar.gz", hash = "sha256:3a8baade6cb80bcfe43297e33e7623f3118d660d41387593758e2fb1ea173a86"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.19-py3-none-any.whl", hash = "sha256:7089d8d2938043508aa9420ec18ce0922885304cddae87fb96eebca942299f88"},
-    {file = "prompt_toolkit-3.0.19.tar.gz", hash = "sha256:08360ee3a3148bdb5163621709ee322ec34fc4375099afa4bbf751e9b7b7fa4f"},
+    {file = "prompt_toolkit-3.0.20-py3-none-any.whl", hash = "sha256:6076e46efae19b1e0ca1ec003ed37a933dc94b4d20f486235d436e64771dcd5c"},
+    {file = "prompt_toolkit-3.0.20.tar.gz", hash = "sha256:eb71d5a6b72ce6db177af4a7d4d7085b99756bf656d98ffcc4fecd36850eea6c"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -2118,43 +2148,51 @@ qtconsole = [
     {file = "qtconsole-5.1.1.tar.gz", hash = "sha256:bbc34bca14f65535afcb401bc74b752bac955e5313001ba640383f7e5857dc49"},
 ]
 qtpy = [
-    {file = "QtPy-1.9.0-py2.py3-none-any.whl", hash = "sha256:fa0b8363b363e89b2a6f49eddc162a04c0699ae95e109a6be3bb145a913190ea"},
-    {file = "QtPy-1.9.0.tar.gz", hash = "sha256:2db72c44b55d0fe1407be8fba35c838ad0d6d3bb81f23007886dc1fc0f459c8d"},
+    {file = "QtPy-1.10.0-py2.py3-none-any.whl", hash = "sha256:f683ce6cd825ba8248a798bf1dfa1a07aca387c88ae44fa5479537490aace7be"},
+    {file = "QtPy-1.10.0.tar.gz", hash = "sha256:3d20f010caa3b2c04835d6a2f66f8873b041bdaf7a76085c2a0d7890cdd65ea9"},
 ]
 regex = [
-    {file = "regex-2021.8.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8764a78c5464ac6bde91a8c87dd718c27c1cabb7ed2b4beaf36d3e8e390567f9"},
-    {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4551728b767f35f86b8e5ec19a363df87450c7376d7419c3cac5b9ceb4bce576"},
-    {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:577737ec3d4c195c4aef01b757905779a9e9aee608fa1cf0aec16b5576c893d3"},
-    {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c856ec9b42e5af4fe2d8e75970fcc3a2c15925cbcc6e7a9bcb44583b10b95e80"},
-    {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3835de96524a7b6869a6c710b26c90e94558c31006e96ca3cf6af6751b27dca1"},
-    {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cea56288eeda8b7511d507bbe7790d89ae7049daa5f51ae31a35ae3c05408531"},
-    {file = "regex-2021.8.3-cp36-cp36m-win32.whl", hash = "sha256:a4eddbe2a715b2dd3849afbdeacf1cc283160b24e09baf64fa5675f51940419d"},
-    {file = "regex-2021.8.3-cp36-cp36m-win_amd64.whl", hash = "sha256:57fece29f7cc55d882fe282d9de52f2f522bb85290555b49394102f3621751ee"},
-    {file = "regex-2021.8.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a5c6dbe09aff091adfa8c7cfc1a0e83fdb8021ddb2c183512775a14f1435fe16"},
-    {file = "regex-2021.8.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff4a8ad9638b7ca52313d8732f37ecd5fd3c8e3aff10a8ccb93176fd5b3812f6"},
-    {file = "regex-2021.8.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b63e3571b24a7959017573b6455e05b675050bbbea69408f35f3cb984ec54363"},
-    {file = "regex-2021.8.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fbc20975eee093efa2071de80df7f972b7b35e560b213aafabcec7c0bd00bd8c"},
-    {file = "regex-2021.8.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14caacd1853e40103f59571f169704367e79fb78fac3d6d09ac84d9197cadd16"},
-    {file = "regex-2021.8.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bb350eb1060591d8e89d6bac4713d41006cd4d479f5e11db334a48ff8999512f"},
-    {file = "regex-2021.8.3-cp37-cp37m-win32.whl", hash = "sha256:18fdc51458abc0a974822333bd3a932d4e06ba2a3243e9a1da305668bd62ec6d"},
-    {file = "regex-2021.8.3-cp37-cp37m-win_amd64.whl", hash = "sha256:026beb631097a4a3def7299aa5825e05e057de3c6d72b139c37813bfa351274b"},
-    {file = "regex-2021.8.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:16d9eaa8c7e91537516c20da37db975f09ac2e7772a0694b245076c6d68f85da"},
-    {file = "regex-2021.8.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3905c86cc4ab6d71635d6419a6f8d972cab7c634539bba6053c47354fd04452c"},
-    {file = "regex-2021.8.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:937b20955806381e08e54bd9d71f83276d1f883264808521b70b33d98e4dec5d"},
-    {file = "regex-2021.8.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:28e8af338240b6f39713a34e337c3813047896ace09d51593d6907c66c0708ba"},
-    {file = "regex-2021.8.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c09d88a07483231119f5017904db8f60ad67906efac3f1baa31b9b7f7cca281"},
-    {file = "regex-2021.8.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:85f568892422a0e96235eb8ea6c5a41c8ccbf55576a2260c0160800dbd7c4f20"},
-    {file = "regex-2021.8.3-cp38-cp38-win32.whl", hash = "sha256:bf6d987edd4a44dd2fa2723fca2790f9442ae4de2c8438e53fcb1befdf5d823a"},
-    {file = "regex-2021.8.3-cp38-cp38-win_amd64.whl", hash = "sha256:8fe58d9f6e3d1abf690174fd75800fda9bdc23d2a287e77758dc0e8567e38ce6"},
-    {file = "regex-2021.8.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7976d410e42be9ae7458c1816a416218364e06e162b82e42f7060737e711d9ce"},
-    {file = "regex-2021.8.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9569da9e78f0947b249370cb8fadf1015a193c359e7e442ac9ecc585d937f08d"},
-    {file = "regex-2021.8.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:459bbe342c5b2dec5c5223e7c363f291558bc27982ef39ffd6569e8c082bdc83"},
-    {file = "regex-2021.8.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4f421e3cdd3a273bace013751c345f4ebeef08f05e8c10757533ada360b51a39"},
-    {file = "regex-2021.8.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea212df6e5d3f60341aef46401d32fcfded85593af1d82b8b4a7a68cd67fdd6b"},
-    {file = "regex-2021.8.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a3b73390511edd2db2d34ff09aa0b2c08be974c71b4c0505b4a048d5dc128c2b"},
-    {file = "regex-2021.8.3-cp39-cp39-win32.whl", hash = "sha256:f35567470ee6dbfb946f069ed5f5615b40edcbb5f1e6e1d3d2b114468d505fc6"},
-    {file = "regex-2021.8.3-cp39-cp39-win_amd64.whl", hash = "sha256:bfa6a679410b394600eafd16336b2ce8de43e9b13f7fb9247d84ef5ad2b45e91"},
-    {file = "regex-2021.8.3.tar.gz", hash = "sha256:8935937dad2c9b369c3d932b0edbc52a62647c2afb2fafc0c280f14a8bf56a6a"},
+    {file = "regex-2021.8.21-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b0c211c55d4aac4309c3209833c803fada3fc21cdf7b74abedda42a0c9dc3ce"},
+    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d5209c3ba25864b1a57461526ebde31483db295fc6195fdfc4f8355e10f7376"},
+    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c835c30f3af5c63a80917b72115e1defb83de99c73bc727bddd979a3b449e183"},
+    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:615fb5a524cffc91ab4490b69e10ae76c1ccbfa3383ea2fad72e54a85c7d47dd"},
+    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9966337353e436e6ba652814b0a957a517feb492a98b8f9d3b6ba76d22301dcc"},
+    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a49f85f0a099a5755d0a2cc6fc337e3cb945ad6390ec892332c691ab0a045882"},
+    {file = "regex-2021.8.21-cp310-cp310-win32.whl", hash = "sha256:f93a9d8804f4cec9da6c26c8cfae2c777028b4fdd9f49de0302e26e00bb86504"},
+    {file = "regex-2021.8.21-cp310-cp310-win_amd64.whl", hash = "sha256:a795829dc522227265d72b25d6ee6f6d41eb2105c15912c230097c8f5bfdbcdc"},
+    {file = "regex-2021.8.21-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bca14dfcfd9aae06d7d8d7e105539bd77d39d06caaae57a1ce945670bae744e0"},
+    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41acdd6d64cd56f857e271009966c2ffcbd07ec9149ca91f71088574eaa4278a"},
+    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96f0c79a70642dfdf7e6a018ebcbea7ea5205e27d8e019cad442d2acfc9af267"},
+    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:45f97ade892ace20252e5ccecdd7515c7df5feeb42c3d2a8b8c55920c3551c30"},
+    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f9974826aeeda32a76648fc677e3125ade379869a84aa964b683984a2dea9f1"},
+    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea9753d64cba6f226947c318a923dadaf1e21cd8db02f71652405263daa1f033"},
+    {file = "regex-2021.8.21-cp36-cp36m-win32.whl", hash = "sha256:ef9326c64349e2d718373415814e754183057ebc092261387a2c2f732d9172b2"},
+    {file = "regex-2021.8.21-cp36-cp36m-win_amd64.whl", hash = "sha256:6dbd51c3db300ce9d3171f4106da18fe49e7045232630fe3d4c6e37cb2b39ab9"},
+    {file = "regex-2021.8.21-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a89ca4105f8099de349d139d1090bad387fe2b208b717b288699ca26f179acbe"},
+    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6c2b1d78ceceb6741d703508cd0e9197b34f6bf6864dab30f940f8886e04ade"},
+    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a34ba9e39f8269fd66ab4f7a802794ffea6d6ac500568ec05b327a862c21ce23"},
+    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ecb6e7c45f9cd199c10ec35262b53b2247fb9a408803ed00ee5bb2b54aa626f5"},
+    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:330836ad89ff0be756b58758878409f591d4737b6a8cef26a162e2a4961c3321"},
+    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:71a904da8c9c02aee581f4452a5a988c3003207cb8033db426f29e5b2c0b7aea"},
+    {file = "regex-2021.8.21-cp37-cp37m-win32.whl", hash = "sha256:b511c6009d50d5c0dd0bab85ed25bc8ad6b6f5611de3a63a59786207e82824bb"},
+    {file = "regex-2021.8.21-cp37-cp37m-win_amd64.whl", hash = "sha256:93f9f720081d97acee38a411e861d4ce84cbc8ea5319bc1f8e38c972c47af49f"},
+    {file = "regex-2021.8.21-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3a195e26df1fbb40ebee75865f9b64ba692a5824ecb91c078cc665b01f7a9a36"},
+    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06ba444bbf7ede3890a912bd4904bb65bf0da8f0d8808b90545481362c978642"},
+    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b8d551f1bd60b3e1c59ff55b9e8d74607a5308f66e2916948cafd13480b44a3"},
+    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ebbceefbffae118ab954d3cd6bf718f5790db66152f95202ebc231d58ad4e2c2"},
+    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ccd721f1d4fc42b541b633d6e339018a08dd0290dc67269df79552843a06ca92"},
+    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ae87ab669431f611c56e581679db33b9a467f87d7bf197ac384e71e4956b4456"},
+    {file = "regex-2021.8.21-cp38-cp38-win32.whl", hash = "sha256:38600fd58c2996829480de7d034fb2d3a0307110e44dae80b6b4f9b3d2eea529"},
+    {file = "regex-2021.8.21-cp38-cp38-win_amd64.whl", hash = "sha256:61e734c2bcb3742c3f454dfa930ea60ea08f56fd1a0eb52d8cb189a2f6be9586"},
+    {file = "regex-2021.8.21-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b091dcfee169ad8de21b61eb2c3a75f9f0f859f851f64fdaf9320759a3244239"},
+    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:640ccca4d0a6fcc6590f005ecd7b16c3d8f5d52174e4854f96b16f34c39d6cb7"},
+    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac95101736239260189f426b1e361dc1b704513963357dc474beb0f39f5b7759"},
+    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:b79dc2b2e313565416c1e62807c7c25c67a6ff0a0f8d83a318df464555b65948"},
+    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d8b623fc429a38a881ab2d9a56ef30e8ea20c72a891c193f5ebbddc016e083ee"},
+    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8021dee64899f993f4b5cca323aae65aabc01a546ed44356a0965e29d7893c94"},
+    {file = "regex-2021.8.21-cp39-cp39-win32.whl", hash = "sha256:d6ec4ae13760ceda023b2e5ef1f9bc0b21e4b0830458db143794a117fdbdc044"},
+    {file = "regex-2021.8.21-cp39-cp39-win_amd64.whl", hash = "sha256:03840a07a402576b8e3a6261f17eb88abd653ad4e18ec46ef10c9a63f8c99ebd"},
+    {file = "regex-2021.8.21.tar.gz", hash = "sha256:faf08b0341828f6a29b8f7dd94d5cf8cc7c39bfc3e67b78514c54b494b66915a"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
@@ -2227,8 +2265,8 @@ sphinxcontrib-serializinghtml = [
     {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
 ]
 terminado = [
-    {file = "terminado-0.11.0-py3-none-any.whl", hash = "sha256:221eef83e6a504894842f7dccfa971ca2e98ec22a8a9118577e5257527674b42"},
-    {file = "terminado-0.11.0.tar.gz", hash = "sha256:1e01183885f64c1bba3cf89a5a995ad4acfed4e5f00aebcce1bf7f089b0825a1"},
+    {file = "terminado-0.11.1-py3-none-any.whl", hash = "sha256:9e0457334863be3e6060c487ad60e0995fa1df54f109c67b24ff49a4f2f34df5"},
+    {file = "terminado-0.11.1.tar.gz", hash = "sha256:962b402edbb480718054dc37027bada293972ecadfb587b89f01e2b8660a2132"},
 ]
 testpath = [
     {file = "testpath-0.5.0-py3-none-any.whl", hash = "sha256:8044f9a0bab6567fc644a3593164e872543bb44225b0e24846e2c89237937589"},
@@ -2336,6 +2374,10 @@ typer-cli = [
 types-pyyaml = [
     {file = "types-PyYAML-5.4.6.tar.gz", hash = "sha256:745dcb4b1522423026bcc83abb9925fba747f1e8602d902f71a4058f9e7fb662"},
     {file = "types_PyYAML-5.4.6-py3-none-any.whl", hash = "sha256:96f8d3d96aa1a18a465e8f6a220e02cff2f52632314845a364ecbacb0aea6e30"},
+]
+types-requests = [
+    {file = "types-requests-2.25.6.tar.gz", hash = "sha256:e21541c0f55c066c491a639309159556dd8c5833e49fcde929c4c47bdb0002ee"},
+    {file = "types_requests-2.25.6-py3-none-any.whl", hash = "sha256:a5a305b43ea57bf64d6731f89816946a405b591eff6de28d4c0fd58422cee779"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ typer = {extras = ["all"], version = "^0.3.0"}
 jsonschema = "^3.2.0"
 PyYAML = "^5.3.1"
 rich = "^9.12.2"
+arrow = "^1.1.1"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.9"
@@ -60,6 +61,7 @@ flake8 = "^3.9.2"
 black = "^21.7b0"
 mypy = "^0.910"
 types-PyYAML = "^5.4.6"
+types-requests = "^2.25.6"
 
 [tool.isort]
 multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "globus-automate-client"
-version = "0.12.0"
+version = "0.12.1rc1"
 description = "Client for the Globus Flows service"
 authors = [
     "Uriel Mandujano <uriel@globus.org>",


### PR DESCRIPTION
This PR adds support for displaying list data as tabular output [see screenshots below]. Notice that the tabular outputs play well with the other options available on the CLI such as filtering, verbose output, and watching for updates. Only a subset of the API's returned data gets formatted as a table due to the limits of a terminal window but the fields we display can be tweaked (or processed as in the case of the datetime fields in the screenshots). For the full data to be parsed, the output needs to be formatted as either JSON or YAML. On all commands, if the output is specified as JSON, external tools (like JQ) can parse the output and pull specific fields if needed.

The general approach was to separate the `Result` and `Renderer` into distinct objects, and then manage both via a `RequestRunner`. The runner will execute a given callable and then render the result according to the various options (increased verbosity, willingness to poll, output format). A `CompletionDetetector` can be passed as an argument to the `RequestRunner` which is used to determine when a `Result` can be considered complete in the event that polling occurs. Endpoints that have produce list data (such as Flow-list) can also pass a `DisplayFields` object that are used to determine which fields are displayed for a given list item and how to display them.

This PR adds some auto parsing of yaml/json files, no longer requiring users to indicate what type of input they're providing. It also adds an example flow for creating a Run that will become INACTIVE due to ConsentsRequired. It also updates the Queues client to match changes made to the Queue update API endpoint.

Run log output:
<img width="952" alt="Run-Log-Output" src="https://user-images.githubusercontent.com/62311618/130696035-4d44209d-d7df-4207-8b2f-07f7e6676460.png">

Flow list output [with filtering]:
<img width="1005" alt="Flow-List-Output" src="https://user-images.githubusercontent.com/62311618/130708391-131f7b7c-37e1-49b3-a04b-a34e3ec77822.png">

Run enumerate output [with options]:
<img width="1056" alt="Run-Enumerate-Output" src="https://user-images.githubusercontent.com/62311618/130708408-1bd115e0-230f-42d6-b7e7-2a202840d257.png">

Flow action-list output [with authentication]:
<img width="1059" alt="Flow-Action-List-Output" src="https://user-images.githubusercontent.com/62311618/130708420-6d8d1743-a75e-40cd-a405-bec93da14e32.png">

