### PR TITLE
Client updates to allow Fail states in Flows

### DIFF
--- a/docs/source/authoring_flows.rst
+++ b/docs/source/authoring_flows.rst
@@ -35,6 +35,7 @@ below) the same manor as defined in the States Language:
 * `Choice <https://states-language.net/spec.html#choice-state>`_
 
 * `Wait <https://states-language.net/spec.html#choice-state>`_
+* `Fail <https://states-language.net/spec.html#fail-state>`_
 
 .. note::
 

--- a/docs/source/cli_docs.rst
+++ b/docs/source/cli_docs.rst
@@ -240,6 +240,7 @@ GLOBUS_AUTOMATE_FLOWS_ENDPOINT environment variable.
 -  ``action-release``: Remove execution history for a particular…
 -  ``action-resume``: Resume a Flow in the INACTIVE state.
 -  ``action-status``: Display the status for a Flow definition’s…
+-  ``action-update``: Update a Run on the Flows service
 -  ``delete``: Delete a Flow.
 -  ``deploy``: Deploy a new Flow.
 -  ``display``: Visualize a local or deployed Flow defintion.
@@ -254,6 +255,7 @@ GLOBUS_AUTOMATE_FLOWS_ENDPOINT environment variable.
 -  ``run-release``: Remove execution history for a particular…
 -  ``run-resume``: Resume a Flow in the INACTIVE state.
 -  ``run-status``: Display the status for a Flow definition’s…
+-  ``run-update``: Update a Run on the Flows service
 -  ``update``: Update a Flow.
 
 ``globus-automate flow action-cancel``
@@ -341,12 +343,13 @@ List a Flow definition’s discrete invocations.
    If not present runs from all Flows will be displayed.
 -  ``--flow-scope TEXT``: The scope this Flow uses to authenticate
    requests.
--  ``--role [run_monitor|run_manager|run_owner]``: Display Actions/Runs
-   where you have at least the selected role. Precedence of roles is:
-   run_monitor, run_manager, run_owner. Thus, by specifying, for
-   example, run_manager, all runs for which you hvae run_manager or
-   run_owner roles will be displayed. [repeatable use deprecated as the
-   lowest precedence value provided will determine the flows displayed.]
+-  ``--role [run_monitor|run_manager|run_owner|created_by|monitor_by|manage_by]``:
+   Display Actions/Runs where you have at least the selected role.
+   Precedence of roles is: run_monitor, run_manager, run_owner. Thus, by
+   specifying, for example, run_manager, all runs for which you hvae
+   run_manager or run_owner roles will be displayed. [repeatable use
+   deprecated as the lowest precedence value provided will determine the
+   flows displayed.]
 -  ``--status [SUCCEEDED|FAILED|ACTIVE|INACTIVE]``: Display Actions with
    the selected status. [repeatable]
 -  ``-m, --marker TEXT``: A pagination token for iterating through
@@ -485,6 +488,38 @@ Display the status for a Flow definition’s particular invocation.
 -  ``-w, --watch``: Continuously poll this Action until it reaches a
    completed state. [default: False]
 -  ``-v, --verbose``: Run with increased verbosity
+-  ``--help``: Show this message and exit.
+
+``globus-automate flow action-update``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Update a Run on the Flows service
+
+**Usage**:
+
+.. code:: console
+
+   $ globus-automate flow action-update [OPTIONS] ACTION_ID
+
+**Arguments**:
+
+-  ``ACTION_ID``: [required]
+
+**Options**:
+
+-  ``--run-manager TEXT``: A principal which may change the execution of
+   the Run.The principal value is the user’s Globus Auth username or
+   their identity UUID in the form urn:globus:auth:identity:. A Globus
+   Group may also be used using the form urn:globus:groups:id:.
+   [repeatable]
+-  ``--run-monitor TEXT``: A principal which may monitor the execution
+   of the Run.The principal value is the user’s Globus Auth username or
+   their identity UUID in the form urn:globus:auth:identity:. A Globus
+   Group may also be used using the form urn:globus:groups:id:.
+   [repeatable]
+-  ``-v, --verbose``: Run with increased verbosity
+-  ``-f, --format [json|graphviz|image|yaml]``: Output display format.
+   [default: json]
 -  ``--help``: Show this message and exit.
 
 ``globus-automate flow delete``
@@ -804,12 +839,13 @@ List a Flow definition’s discrete invocations.
    If not present runs from all Flows will be displayed.
 -  ``--flow-scope TEXT``: The scope this Flow uses to authenticate
    requests.
--  ``--role [run_monitor|run_manager|run_owner]``: Display Actions/Runs
-   where you have at least the selected role. Precedence of roles is:
-   run_monitor, run_manager, run_owner. Thus, by specifying, for
-   example, run_manager, all runs for which you hvae run_manager or
-   run_owner roles will be displayed. [repeatable use deprecated as the
-   lowest precedence value provided will determine the flows displayed.]
+-  ``--role [run_monitor|run_manager|run_owner|created_by|monitor_by|manage_by]``:
+   Display Actions/Runs where you have at least the selected role.
+   Precedence of roles is: run_monitor, run_manager, run_owner. Thus, by
+   specifying, for example, run_manager, all runs for which you hvae
+   run_manager or run_owner roles will be displayed. [repeatable use
+   deprecated as the lowest precedence value provided will determine the
+   flows displayed.]
 -  ``--status [SUCCEEDED|FAILED|ACTIVE|INACTIVE]``: Display Actions with
    the selected status. [repeatable]
 -  ``-m, --marker TEXT``: A pagination token for iterating through
@@ -948,6 +984,38 @@ Display the status for a Flow definition’s particular invocation.
 -  ``-w, --watch``: Continuously poll this Action until it reaches a
    completed state. [default: False]
 -  ``-v, --verbose``: Run with increased verbosity
+-  ``--help``: Show this message and exit.
+
+``globus-automate flow run-update``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Update a Run on the Flows service
+
+**Usage**:
+
+.. code:: console
+
+   $ globus-automate flow run-update [OPTIONS] ACTION_ID
+
+**Arguments**:
+
+-  ``ACTION_ID``: [required]
+
+**Options**:
+
+-  ``--run-manager TEXT``: A principal which may change the execution of
+   the Run.The principal value is the user’s Globus Auth username or
+   their identity UUID in the form urn:globus:auth:identity:. A Globus
+   Group may also be used using the form urn:globus:groups:id:.
+   [repeatable]
+-  ``--run-monitor TEXT``: A principal which may monitor the execution
+   of the Run.The principal value is the user’s Globus Auth username or
+   their identity UUID in the form urn:globus:auth:identity:. A Globus
+   Group may also be used using the form urn:globus:groups:id:.
+   [repeatable]
+-  ``-v, --verbose``: Run with increased verbosity
+-  ``-f, --format [json|graphviz|image|yaml]``: Output display format.
+   [default: json]
 -  ``--help``: Show this message and exit.
 
 ``globus-automate flow update``

--- a/docs/source/example_flows.rst
+++ b/docs/source/example_flows.rst
@@ -1,0 +1,5 @@
+Example Flows
+=============
+
+For examples of Flows, input schemas, and inputs see the `Globus Automate Client
+repository's examples <https://github.com/globus/globus-automate-client/tree/master/examples/flows>`_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,3 +30,4 @@ implementing the Globus Action Provider Interface, and Globus Queues.
    globus_action_providers
    cli_reference
    python_sdk_reference
+   example_flows

--- a/examples/flows/failed-consent/definition.yaml
+++ b/examples/flows/failed-consent/definition.yaml
@@ -7,7 +7,7 @@ States:
       intervention to complete.
     ActionUrl: https://actions.automate.globus.org/hello_world
     Parameters:
-      echo_string: urn:globus:auth:scope:groups.api.globus.org:all
+      required_dependent_scope: urn:globus:auth:scope:groups.api.globus.org:all
     ResultPath: $.FlowResult
     Next: FailState
 

--- a/examples/flows/failed-consent/definition.yaml
+++ b/examples/flows/failed-consent/definition.yaml
@@ -1,0 +1,20 @@
+StartAt: HelloState
+States:
+  HelloState:
+    Type: Action
+    Comment: >-
+      This state will always result in an INACTIVE run, requiring user
+      intervention to complete.
+    ActionUrl: https://actions.automate.globus.org/hello_world
+    Parameters:
+      echo_string: urn:globus:auth:scope:groups.api.globus.org:all
+    ResultPath: $.FlowResult
+    Next: FailState
+
+  FailState:
+    Type: Fail
+    Comment: This state will terminate the Flow and show it as FAILED
+    Cause: >-
+      The text provided here will appear in the Run's details failure
+      information
+    Error: YourErrorCode

--- a/examples/flows/failed-consent/schema.yaml
+++ b/examples/flows/failed-consent/schema.yaml
@@ -1,0 +1,1 @@
+additionalProperties: false

--- a/globus_automate_client/flows_schema.json
+++ b/globus_automate_client/flows_schema.json
@@ -1,806 +1,832 @@
 {
-  "$id": "https://globus.org/schemas/flow_schama.json",
-  "schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
-  "required": [
-    "StartAt",
-    "States"
-  ],
-  "properties": {
-    "Comment": {
-      "type": "string"
-    },
-    "StartAt": {
-      "type": "string"
-    },
-    "States": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "required": [
-          "Type"
-        ],
-        "properties": {
-          "Type": {
-            "type": "string",
-            "enum": [
-              "Pass",
-              "Action",
-              "Wait",
-              "Choice",
-              "ExpressionEval"
-            ]
-          }
+    "$id": "https://globus.org/schemas/flow_schama.json",
+    "schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "required": [
+        "StartAt",
+        "States"
+    ],
+    "properties": {
+        "Comment": {
+            "type": "string"
         },
-        "allOf": [
-          {
-            "if": {
-              "properties": {
-                "Type": {
-                  "const": "Pass"
-                }
-              }
-            },
-            "then": {
-              "$ref": "#/definitions/Pass"
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "Type": {
-                  "const": "Action"
-                }
-              }
-            },
-            "then": {
-              "$ref": "#/definitions/Action"
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "Type": {
-                  "const": "ExpressionEval"
-                }
-              }
-            },
-            "then": {
-              "$ref": "#/definitions/ExpressionEval"
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "Type": {
-                  "const": "Wait"
-                }
-              }
-            },
-            "then": {
-              "$ref": "#/definitions/Wait"
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "Type": {
-                  "const": "Choice"
-                }
-              }
-            },
-            "then": {
-              "$ref": "#/definitions/Choice"
-            }
-          }
-        ]
-      }
-    }
-  },
-  "definitions": {
-    "JsonPathPattern": {
-      "type": "string",
-      "pattern": "^\\$\\..*"
-    },
-    "JsonPathReferencePattern": {
-      "type": "string",
-      "pattern": "^\\$\\..*"
-    },
-    "NextOrEnd": {
-      "oneOf": [
-        {
-          "required": [
-            "Next"
-          ]
+        "StartAt": {
+            "type": "string"
         },
-        {
-          "required": [
-            "End"
-          ]
-        }
-      ],
-      "properties": {
-        "Next": {
-          "type": "string"
-        },
-        "End": {
-          "type": "boolean"
-        }
-      }
-    },
-    "Parameters": {
-      "properties": {
-        "Parameters": {
-          "type": "object",
-          "patternProperties": {
-            ".*\\.\\$": {
-              "$ref": "#/definitions/JsonPathPattern"
-            }
-          }
-        }
-      }
-    },
-    "InputPath": {
-      "properties": {
-        "InputPath": {
-          "$ref": "#/definitions/JsonPathReferencePattern"
-        }
-      }
-    },
-    "ResultPath": {
-      "properties": {
-        "ResultPath": {
-          "$ref": "#/definitions/JsonPathReferencePattern"
-        }
-      }
-    },
-    "ParametersOrInputPathNotRequired": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Parameters"
-        },
-        {
-          "$ref": "#/definitions/InputPath"
-        }
-      ]
-    },
-    "ParametersOrInputPath": {
-      "oneOf": [
-        {
-          "required": [
-            "Parameters"
-          ]
-        },
-        {
-          "required": [
-            "InputPath"
-          ]
-        }
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/Parameters"
-        },
-        {
-          "$ref": "#/definitions/InputPath"
-        }
-      ]
-    },
-    "Pass": {
-      "allOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "Result": {
-              "type": "object"
-            },
-            "Type": {},
-            "Comment": {},
-            "Next": {},
-            "End": {},
-            "InputPath": {},
-            "Parameters": {},
-            "ResultPath": {}
-          }
-        },
-        {
-          "$ref": "#/definitions/NextOrEnd"
-        },
-        {
-          "$ref": "#/definitions/ParametersOrInputPathNotRequired"
-        },
-        {
-          "$ref": "#/definitions/ResultPath"
-        }
-      ]
-    },
-    "Catch": {
-      "properties": {
-        "Catch": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
+        "States": {
             "type": "object",
-            "allOf": [
-              {
-                "additionalProperties": false,
+            "additionalProperties": {
+                "type": "object",
                 "required": [
-                  "ErrorEquals",
-                  "Next"
+                    "Type"
                 ],
                 "properties": {
-                  "ErrorEquals": {
+                    "Type": {
+                        "type": "string",
+                        "enum": [
+                            "Pass",
+                            "Action",
+                            "Wait",
+                            "Choice",
+                            "ExpressionEval",
+                            "Fail"
+                        ]
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": {
+                                "Type": {
+                                    "const": "Pass"
+                                }
+                            }
+                        },
+                        "then": {
+                            "$ref": "#/definitions/Pass"
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "Type": {
+                                    "const": "Action"
+                                }
+                            }
+                        },
+                        "then": {
+                            "$ref": "#/definitions/Action"
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "Type": {
+                                    "const": "ExpressionEval"
+                                }
+                            }
+                        },
+                        "then": {
+                            "$ref": "#/definitions/ExpressionEval"
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "Type": {
+                                    "const": "Wait"
+                                }
+                            }
+                        },
+                        "then": {
+                            "$ref": "#/definitions/Wait"
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "Type": {
+                                    "const": "Choice"
+                                }
+                            }
+                        },
+                        "then": {
+                            "$ref": "#/definitions/Choice"
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "Type": {
+                                    "const": "Fail"
+                                }
+                            }
+                        },
+                        "then": {
+                            "$ref": "#/definitions/Fail"
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "definitions": {
+        "JsonPathPattern": {
+            "type": "string",
+            "pattern": "^\\$\\..*"
+        },
+        "JsonPathReferencePattern": {
+            "type": "string",
+            "pattern": "^\\$\\..*"
+        },
+        "NextOrEnd": {
+            "oneOf": [
+                {
+                    "required": [
+                        "Next"
+                    ]
+                },
+                {
+                    "required": [
+                        "End"
+                    ]
+                }
+            ],
+            "properties": {
+                "Next": {
+                    "type": "string"
+                },
+                "End": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "Parameters": {
+            "properties": {
+                "Parameters": {
+                    "type": "object",
+                    "patternProperties": {
+                        ".*\\.\\$": {
+                            "$ref": "#/definitions/JsonPathPattern"
+                        }
+                    }
+                }
+            }
+        },
+        "InputPath": {
+            "properties": {
+                "InputPath": {
+                    "$ref": "#/definitions/JsonPathReferencePattern"
+                }
+            }
+        },
+        "ResultPath": {
+            "properties": {
+                "ResultPath": {
+                    "$ref": "#/definitions/JsonPathReferencePattern"
+                }
+            }
+        },
+        "ParametersOrInputPathNotRequired": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Parameters"
+                },
+                {
+                    "$ref": "#/definitions/InputPath"
+                }
+            ]
+        },
+        "ParametersOrInputPath": {
+            "oneOf": [
+                {
+                    "required": [
+                        "Parameters"
+                    ]
+                },
+                {
+                    "required": [
+                        "InputPath"
+                    ]
+                }
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Parameters"
+                },
+                {
+                    "$ref": "#/definitions/InputPath"
+                }
+            ]
+        },
+        "Pass": {
+            "allOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "Result": {
+                            "type": "object"
+                        },
+                        "Type": {},
+                        "Comment": {},
+                        "Next": {},
+                        "End": {},
+                        "InputPath": {},
+                        "Parameters": {},
+                        "ResultPath": {}
+                    }
+                },
+                {
+                    "$ref": "#/definitions/NextOrEnd"
+                },
+                {
+                    "$ref": "#/definitions/ParametersOrInputPathNotRequired"
+                },
+                {
+                    "$ref": "#/definitions/ResultPath"
+                }
+            ]
+        },
+        "Catch": {
+            "properties": {
+                "Catch": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "allOf": [
+                            {
+                                "additionalProperties": false,
+                                "required": [
+                                    "ErrorEquals",
+                                    "Next"
+                                ],
+                                "properties": {
+                                    "ErrorEquals": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "minItems": 1,
+                                        "uniqueItems": true
+                                    },
+                                    "Next": {
+                                        "type": "string"
+                                    },
+                                    "ResultPath": {}
+                                }
+                            },
+                            {
+                                "$ref": "#/definitions/ResultPath"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "Action": {
+            "allOf": [
+                {
+                    "additionalProperties": false,
+                    "required": [
+                        "Type",
+                        "ActionUrl"
+                    ],
+                    "properties": {
+                        "ActionUrl": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "ActionScope": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "RunAs": {
+                            "type": "string"
+                        },
+                        "ExceptionOnActionFailure": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "WaitTime": {
+                            "type": "integer"
+                        },
+                        "Type": {},
+                        "Comment": {},
+                        "Next": {},
+                        "End": {},
+                        "InputPath": {},
+                        "Parameters": {},
+                        "ResultPath": {},
+                        "Catch": {}
+                    }
+                },
+                {
+                    "$ref": "#/definitions/NextOrEnd"
+                },
+                {
+                    "$ref": "#/definitions/ParametersOrInputPath"
+                },
+                {
+                    "$ref": "#/definitions/ResultPath"
+                },
+                {
+                    "$ref": "#/definitions/Catch"
+                }
+            ]
+        },
+        "ExpressionEval": {
+            "allOf": [
+                {
+                    "additionalProperties": false,
+                    "required": [
+                        "Next",
+                        "Parameters",
+                        "ResultPath"
+                    ],
+                    "properties": {
+                        "Type": {},
+                        "Comment": {},
+                        "Parameters": {},
+                        "ResultPath": {},
+                        "Next": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/Parameters"
+                },
+                {
+                    "$ref": "#/definitions/ResultPath"
+                }
+            ]
+        },
+        "Wait": {
+            "additionalProperties": false,
+            "oneOf": [
+                {
+                    "required": [
+                        "Seconds"
+                    ]
+                },
+                {
+                    "required": [
+                        "SecondsPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Timestamp"
+                    ]
+                },
+                {
+                    "required": [
+                        "TimestampPath"
+                    ]
+                }
+            ],
+            "properties": {
+                "Type": {},
+                "Comment": {},
+                "Next": {
+                    "type": "string"
+                },
+                "Seconds": {
+                    "type": "integer",
+                    "maximum": 31536000
+                },
+                "SecondsPath": {
+                    "$ref": "#/definitions/JsonPathPattern"
+                },
+                "Timestamp": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "TimestampPath": {
+                    "$ref": "#/definitions/JsonPathPattern"
+                }
+            }
+        },
+        "ChoiceRule": {
+            "oneOf": [
+                {
+                    "required": [
+                        "And"
+                    ]
+                },
+                {
+                    "required": [
+                        "Or"
+                    ]
+                },
+                {
+                    "required": [
+                        "Not"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "StringEquals"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "StringEqualsPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "StringLessThan"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "StringLessThanPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "StringGreaterThan"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "StringGreaterThanPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "StringLessThanEquals"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "StringLessThanEqualsPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "StringGreaterThanEquals"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "StringGreaterThanEqualsPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "StringMatches"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "NumericEquals"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "NumericEqualsPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "NumericLessThan"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "NumericLessThanPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "NumericGreaterThan"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "NumericGreaterThanPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "NumericLessThanEquals"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "NumericLessThanEqualsPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "NumericGreaterThanEquals"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "NumericGreaterThanEqualsPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "BooleanEquals"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "BooleanEqualsPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "TimestampEquals"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "TimestampEqualsPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "TimestampLessThan"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "TimestampLessThanPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "TimestampGreaterThan"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "TimestampGreaterThanPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "TimestampLessThanEquals"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "TimestampLessThanEqualsPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "TimestampGreaterThanEquals"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "TimestampGreaterThanEqualsPath"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "IsNull"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "IsPresent"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "IsNumeric"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "IsString"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "IsBoolean"
+                    ]
+                },
+                {
+                    "required": [
+                        "Variable",
+                        "IsTimestamp"
+                    ]
+                }
+            ],
+            "properties": {
+                "And": {
                     "type": "array",
                     "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "uniqueItems": true
-                  },
-                  "Next": {
+                        "$ref": "#/definitions/ChoiceRule"
+                    }
+                },
+                "Or": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ChoiceRule"
+                    }
+                },
+                "Not": {
+                    "$ref": "#/definitions/ChoiceRule"
+                },
+                "Variable": {
                     "type": "string"
-                  },
-                  "ResultPath": {}
+                },
+                "StringEquals": {
+                    "type": "string"
+                },
+                "StringEqualsPath": {
+                    "type": "string"
+                },
+                "StringLessThan": {
+                    "type": "string"
+                },
+                "StringLessThanPath": {
+                    "type": "string"
+                },
+                "StringGreaterThan": {
+                    "type": "string"
+                },
+                "StringGreaterThanPath": {
+                    "type": "string"
+                },
+                "StringLessThanEquals": {
+                    "type": "string"
+                },
+                "StringLessThanEqualsPath": {
+                    "type": "string"
+                },
+                "StringGreaterThanEquals": {
+                    "type": "string"
+                },
+                "StringGreaterThanEqualsPath": {
+                    "type": "string"
+                },
+                "StringMatches": {
+                    "type": "string"
+                },
+                "NumericEquals": {
+                    "type": "number"
+                },
+                "NumericEqualsPath": {
+                    "type": "string"
+                },
+                "NumericLessThan": {
+                    "type": "number"
+                },
+                "NumericLessThanPath": {
+                    "type": "string"
+                },
+                "NumericGreaterThan": {
+                    "type": "number"
+                },
+                "NumericGreaterThanPath": {
+                    "type": "string"
+                },
+                "NumericLessThanEquals": {
+                    "type": "number"
+                },
+                "NumericLessThanEqualsPath": {
+                    "type": "string"
+                },
+                "NumericGreaterThanEquals": {
+                    "type": "number"
+                },
+                "NumericGreaterThanEqualsPath": {
+                    "type": "string"
+                },
+                "BooleanEquals": {
+                    "type": "boolean"
+                },
+                "BooleanEqualsPath": {
+                    "type": "string"
+                },
+                "TimestampEquals": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "TimestampEqualsPath": {
+                    "type": "string"
+                },
+                "TimestampLessThan": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "TimestampLessThanPath": {
+                    "type": "string"
+                },
+                "TimestampGreaterThan": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "TimestampGreaterThanPath": {
+                    "type": "string"
+                },
+                "TimestampLessThanEquals": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "TimestampLessThanEqualsPath": {
+                    "type": "string"
+                },
+                "TimestampGreaterThanEquals": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "TimestampGreaterThanEqualsPath": {
+                    "type": "string"
+                },
+                "IsNull": {
+                    "type": "boolean"
+                },
+                "IsPresent": {
+                    "type": "boolean"
+                },
+                "IsNumeric": {
+                    "type": "boolean"
+                },
+                "IsString": {
+                    "type": "boolean"
+                },
+                "IsBoolean": {
+                    "type": "boolean"
+                },
+                "IsTimestamp": {
+                    "type": "boolean"
                 }
-              },
-              {
-                "$ref": "#/definitions/ResultPath"
-              }
-            ]
-          }
-        }
-      }
-    },
-    "Action": {
-      "allOf": [
-        {
-          "additionalProperties": false,
-          "required": [
-            "Type",
-            "ActionUrl"
-          ],
-          "properties": {
-            "ActionUrl": {
-              "type": "string",
-              "format": "uri"
-            },
-            "ActionScope": {
-              "type": "string",
-              "format": "uri"
-            },
-            "RunAs": {
-              "type": "string"
-            },
-            "ExceptionOnActionFailure": {
-              "type": "boolean",
-              "default": false
-            },
-            "WaitTime": {
-              "type": "integer"
-            },
-            "Type": {},
-            "Comment": {},
-            "Next": {},
-            "End": {},
-            "InputPath": {},
-            "Parameters": {},
-            "ResultPath": {},
-            "Catch": {}
-          }
-        },
-        {
-          "$ref": "#/definitions/NextOrEnd"
-        },
-        {
-          "$ref": "#/definitions/ParametersOrInputPath"
-        },
-        {
-          "$ref": "#/definitions/ResultPath"
-        },
-        {
-          "$ref": "#/definitions/Catch"
-        }
-      ]
-    },
-    "ExpressionEval": {
-      "allOf": [
-        {
-          "additionalProperties": false,
-          "required": [
-            "Next",
-            "Parameters",
-            "ResultPath"
-          ],
-          "properties": {
-            "Type": {},
-            "Comment": {},
-            "Parameters": {},
-            "ResultPath": {},
-            "Next": {
-              "type": "string"
             }
-          }
         },
-        {
-          "$ref": "#/definitions/Parameters"
-        },
-        {
-          "$ref": "#/definitions/ResultPath"
-        }
-      ]
-    },
-    "Wait": {
-      "additionalProperties": false,
-      "oneOf": [
-        {
-          "required": [
-            "Seconds"
-          ]
-        },
-        {
-          "required": [
-            "SecondsPath"
-          ]
-        },
-        {
-          "required": [
-            "Timestamp"
-          ]
-        },
-        {
-          "required": [
-            "TimestampPath"
-          ]
-        }
-      ],
-      "properties": {
-        "Type": {},
-        "Comment": {},
-        "Next": {
-          "type": "string"
-        },
-        "Seconds": {
-          "type": "integer",
-          "maximum": 31536000
-        },
-        "SecondsPath": {
-          "$ref": "#/definitions/JsonPathPattern"
-        },
-        "Timestamp": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "TimestampPath": {
-          "$ref": "#/definitions/JsonPathPattern"
-        }
-      }
-    },
-    "ChoiceRule": {
-      "oneOf": [
-        {
-          "required": [
-            "And"
-          ]
-        },
-        {
-          "required": [
-            "Or"
-          ]
-        },
-        {
-          "required": [
-            "Not"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "StringEquals"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "StringEqualsPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "StringLessThan"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "StringLessThanPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "StringGreaterThan"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "StringGreaterThanPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "StringLessThanEquals"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "StringLessThanEqualsPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "StringGreaterThanEquals"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "StringGreaterThanEqualsPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "StringMatches"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "NumericEquals"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "NumericEqualsPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "NumericLessThan"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "NumericLessThanPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "NumericGreaterThan"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "NumericGreaterThanPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "NumericLessThanEquals"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "NumericLessThanEqualsPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "NumericGreaterThanEquals"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "NumericGreaterThanEqualsPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "BooleanEquals"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "BooleanEqualsPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "TimestampEquals"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "TimestampEqualsPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "TimestampLessThan"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "TimestampLessThanPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "TimestampGreaterThan"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "TimestampGreaterThanPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "TimestampLessThanEquals"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "TimestampLessThanEqualsPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "TimestampGreaterThanEquals"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "TimestampGreaterThanEqualsPath"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "IsNull"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "IsPresent"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "IsNumeric"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "IsString"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "IsBoolean"
-          ]
-        },
-        {
-          "required": [
-            "Variable",
-            "IsTimestamp"
-          ]
-        }
-      ],
-      "properties": {
-        "And": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ChoiceRule"
-          }
-        },
-        "Or": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ChoiceRule"
-          }
-        },
-        "Not": {
-          "$ref": "#/definitions/ChoiceRule"
-        },
-        "Variable": {
-          "type": "string"
-        },
-        "StringEquals": {
-          "type": "string"
-        },
-        "StringEqualsPath": {
-          "type": "string"
-        },
-        "StringLessThan": {
-          "type": "string"
-        },
-        "StringLessThanPath": {
-          "type": "string"
-        },
-        "StringGreaterThan": {
-          "type": "string"
-        },
-        "StringGreaterThanPath": {
-          "type": "string"
-        },
-        "StringLessThanEquals": {
-          "type": "string"
-        },
-        "StringLessThanEqualsPath": {
-          "type": "string"
-        },
-        "StringGreaterThanEquals": {
-          "type": "string"
-        },
-        "StringGreaterThanEqualsPath": {
-          "type": "string"
-        },
-        "StringMatches": {
-          "type": "string"
-        },
-        "NumericEquals": {
-          "type": "number"
-        },
-        "NumericEqualsPath": {
-          "type": "string"
-        },
-        "NumericLessThan": {
-          "type": "number"
-        },
-        "NumericLessThanPath": {
-          "type": "string"
-        },
-        "NumericGreaterThan": {
-          "type": "number"
-        },
-        "NumericGreaterThanPath": {
-          "type": "string"
-        },
-        "NumericLessThanEquals": {
-          "type": "number"
-        },
-        "NumericLessThanEqualsPath": {
-          "type": "string"
-        },
-        "NumericGreaterThanEquals": {
-          "type": "number"
-        },
-        "NumericGreaterThanEqualsPath": {
-          "type": "string"
-        },
-        "BooleanEquals": {
-          "type": "boolean"
-        },
-        "BooleanEqualsPath": {
-          "type": "string"
-        },
-        "TimestampEquals": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "TimestampEqualsPath": {
-          "type": "string"
-        },
-        "TimestampLessThan": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "TimestampLessThanPath": {
-          "type": "string"
-        },
-        "TimestampGreaterThan": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "TimestampGreaterThanPath": {
-          "type": "string"
-        },
-        "TimestampLessThanEquals": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "TimestampLessThanEqualsPath": {
-          "type": "string"
-        },
-        "TimestampGreaterThanEquals": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "TimestampGreaterThanEqualsPath": {
-          "type": "string"
-        },
-        "IsNull": {
-          "type": "boolean"
-        },
-        "IsPresent": {
-          "type": "boolean"
-        },
-        "IsNumeric": {
-          "type": "boolean"
-        },
-        "IsString": {
-          "type": "boolean"
-        },
-        "IsBoolean": {
-          "type": "boolean"
-        },
-        "IsTimestamp": {
-          "type": "boolean"
-        }
-      }
-    },
-    "Choice": {
-      "additionalProperties": false,
-      "required": [
-        "Choices"
-      ],
-      "properties": {
-        "Type": {},
-        "Comment": {},
-        "Default": {
-          "type": "string"
-        },
-        "Choices": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "allOf": [
-              {
-                "properties": {
-                  "Next": {
+        "Choice": {
+            "additionalProperties": false,
+            "required": [
+                "Choices"
+            ],
+            "properties": {
+                "Type": {},
+                "Comment": {},
+                "Default": {
                     "type": "string"
-                  }
+                },
+                "Choices": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "allOf": [
+                            {
+                                "properties": {
+                                    "Next": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            {
+                                "$ref": "#/definitions/ChoiceRule"
+                            }
+                        ]
+                    }
                 }
-              },
-              {
-                "$ref": "#/definitions/ChoiceRule"
-              }
-            ]
-          }
+            }
+        },
+        "Fail": {
+            "additionalProperties": false,
+            "properties": {
+                "Type": {},
+                "Comment": {},
+                "Error": {
+                    "type": "string"
+                },
+                "Cause": {
+                    "type": "string"
+                }
+            }
         }
-      }
     }
-  }
 }


### PR DESCRIPTION
This PR:

- Updates the local copy of the Flows service OpenAPI spec to include the new Fail state
- Adds a new example Flow [failed-consent] to demonstrate how you can plug a Fail state into a Flow definition
- Updates the CLI documentation (it had been a while since we did this)
- Updates docs to reference supporting the new Fail state
- Adds a page to the docs that links to our GH repo flow examples