### PR TITLE
Add workflow to check for changelog fragments

### DIFF
--- a/.github/workflows/has_changelog.yaml
+++ b/.github/workflows/has_changelog.yaml
@@ -1,0 +1,22 @@
+name: has_changelog
+on:
+  - pull_request
+
+jobs:
+  check_has_news_in_changelog_dir:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'no-news-is-good-news') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:  # do a deep fetch to allow merge-base and diff
+          fetch-depth: 0
+      - name: check PR adds a news file
+        run: |
+          news_files="$(git diff --name-only "$(git merge-base origin/master "$GITHUB_SHA")" "$GITHUB_SHA" -- changelog.d/*.rst)"
+          if [ -n "$news_files" ]; then
+            echo "Saw new files. changelog.d:"
+            echo "$news_files"
+          else
+            echo "No news files seen"
+            exit 1
+          fi


### PR DESCRIPTION
Per our discussion a while ago, this is a simple workflow to check for the addition of changelog fragments in a PR, or else a PR label (which I added for this one).

Here we're checking for `*.rst` files specifically, but honestly it could just be any new files in `changelog.d` which might make it easier to duplicate for other repositories, though easier to miss if someone accidentally creates a fragment in the wrong format.