### PR TITLE
Document the HTTP action provider

### DIFF
--- a/changelog.d/20211112_133005_kurtmckee_doc_http_action_provider.rst
+++ b/changelog.d/20211112_133005_kurtmckee_doc_http_action_provider.rst
@@ -1,0 +1,4 @@
+Documentation
+-------------
+
+-   Document how to interact with the HTTP action provider.

--- a/docs/source/globus_action_providers.rst
+++ b/docs/source/globus_action_providers.rst
@@ -617,15 +617,15 @@ For example, the URL may require an ID to be embedded in the path:
 
     https://domain.example/dataset/37/status/42/info
 
-When this is required you can specify substitution patterns in the ``url``
+When this is required you can specify substitution identifiers in the ``url``
 and dynamically provide the correct values in the input document.
 
-Substitution patterns in the URL are wrapped in curly braces like "``{id}``".
-You can specify multiple substitution patterns, and patterns can be repeated.
-Each pattern MUST be referenced as a key in the ``url-substitutions`` object.
+Substitution identifiers in the URL are wrapped in curly braces like "``{id}``".
+You can specify multiple substitution identifiers, and identifiers can be repeated.
+Each identifier MUST be referenced as a key in the ``url-substitutions`` object.
 
-If patterns are specified in the URL but are not provided in the ``url-substitutions`` object an error will be returned.
-Similarly, if pattern values are provided in ``url-substitutions`` but are not required then this will also be treated as an error.
+If identifiers are specified in the URL but are not provided in the ``url-substitutions`` object an error will be returned.
+Similarly, if identifier values are provided in ``url-substitutions`` but are not required then this will also be treated as an error.
 
 The input document below will result in the same URL as the example above,
 but the dataset ID and the status ID can now be dynamically specified during Flow execution.
@@ -697,23 +697,23 @@ Errors: Additional input documentation validation
 Additional validation of the input document will be performed before submitting the HTTP request.
 These errors may be returned in the result document:
 
-``HTTP_URL_SUBSTITUTION_EMPTY_PATTERN``
-    All URL substitution patterns must have an identifier with at least one character.
+``HTTP_URL_SUBSTITUTION_EMPTY_ID``
+    All URL substitution identifiers must have at least one character.
 
-    If this error is encountered it means that an empty pattern was encountered in the ``url`` key.
-    An empty pattern is literally two curly braces next to each other: "``{}``".
+    If this error is encountered it means that an empty identifier was encountered in the ``url`` key.
+    An empty identifier is two curly braces next to each other: "``{}``".
 
     If literal curly braces must appear in the URL,
     please see the section above titled "URL substitutions" for a workaround.
 
-    If a value is required at that location in the URL, give the pattern a name using at least one character.
+    If a value is required at that location in the URL, give the identifier a name using at least one character.
     Otherwise, remove the curly braces from the URL.
 
-``HTTP_URL_SUBSTITUTION_REQUIREMENTS_NOT_MET``
-    All substitution patterns in ``url`` must have values specified in ``url-substitutions``.
+``HTTP_URL_SUBSTITUTION_ID_UNFILLED``
+    All substitution identifiers in ``url`` must have values specified in ``url-substitutions``.
 
-    If this error is encountered it means that one or more patterns do not have values.
-    For example, the following URL contains two patterns (``dataset-id`` and ``status-id``)
+    If this error is encountered it means that one or more identifiers do not have values.
+    For example, the following URL contains two identifiers (``dataset-id`` and ``status-id``)
     but only one value (``dataset-id``) is provided in ``url-substitutions``:
 
     ..  code-block:: json
@@ -726,13 +726,13 @@ These errors may be returned in the result document:
             }
         }
 
-    To fix this error, provide a value for each substitution pattern that appears in ``url``.
+    To fix this error, provide a value for each substitution identifier that appears in ``url``.
 
-``HTTP_URL_SUBSTITUTION_UNUSED_SUBSTITUTIONS``
+``HTTP_URL_SUBSTITUTION_ID_UNKNOWN``
     All substitution values in ``url-substitutions`` must be required in ``url``.
 
     If you see this error it means that one or more values would be unused in the ``url``.
-    For example, the following URL contains one pattern (``dataset-id``)
+    For example, the following URL contains one identifier (``dataset-id``)
     but two values (``dataset-id`` and ``status-id``) are provided in ``url-substitutions``:
 
     ..  code-block:: json
@@ -746,7 +746,7 @@ These errors may be returned in the result document:
             }
         }
 
-    To fix this error, only provide values for each substitution pattern that appears in ``url``.
+    To fix this error, only provide values for each substitution identifier that appears in ``url``.
 
 ``HTTP_METHOD_DOES_NOT_SUPPORT_CONTENT``
     The HTTP specification does not allow content to be submitted with GET requests.

--- a/docs/source/globus_action_providers.rst
+++ b/docs/source/globus_action_providers.rst
@@ -432,7 +432,6 @@ Here is an example of the simplest functional input document:
 A single HTTP request can be customized in four key ways:
 
 *   HTTP method
-*   HTTP timeout
 *   Content submission
 *   URL customization
 
@@ -477,29 +476,6 @@ The ``url`` key indicates the target URL that will be accessed by the HTTP reque
 
 It can be manipulated and augmented dynamically using query parameters and URL substitution identifiers, which are documented below.
 
-
-
-HTTP timeout
-............
-
-..  csv-table::
-
-    "Key name", "``timeout``"
-    "Value type", "number"
-    "Required", "False"
-    "Value range", "``(0, 30]``"
-    "Default", "``10``"
-
-In some cases an HTTP request may take longer than expected to respond.
-You can customize the maximum length of time that a single request can take using the ``timeout`` key.
-
-..  code-block:: json
-
-    {
-        "method": "GET",
-        "url": "https://domain.example/lengthy-calculation",
-        "timeout": 30
-    }
 
 
 Content submission
@@ -769,7 +745,7 @@ Errors: HTTP request or response failures
     This error can happen for many reasons.
     For example, you may see this error if the ``url`` contains a typo,
     or if the ``url`` refers to an internal server that cannot be reached from the outside internet,
-    or if the server doesn't respond before the ``timeout`` value is reached.
+    or if the server doesn't respond within 5 (five) seconds.
 
     The text of the failure is included in the error message and can help troubleshoot why the request failed.
 

--- a/docs/source/globus_action_providers.rst
+++ b/docs/source/globus_action_providers.rst
@@ -1,18 +1,15 @@
 Globus Action Providers
 =======================
 
-Globus provides and operates a number of ``Action Providers`` which may be
-invoked directly or used within Flows. Below is a brief summary of the ``Action
-Providers`` being operated including specific information on their URLs, scopes,
-and a summary of their functionality. Specific input specifications are not
-provided as they may be retrieved from the ``Action Provider`` directly via
-introspection:
+Globus provides and operates a number of ``Action Providers`` which may be invoked directly or used within Flows.
+Below is a brief summary of the ``Action Providers`` being operated including specific information on their URLs, scopes, and a summary of their functionality.
+Specific input specifications are generally not provided as they may be authoritatively retrieved from the ``Action Provider`` directly via introspection:
 
-.. code-block:: BASH
+.. code-block:: bash
 
     globus-automate action introspect --action-url <action_url>
 
-Or simply click on the URL to view the introspection results in a browser.
+You can also click on the Action URL in the documentation to view the introspection results in a browser.
 
 .. note::
     When running Globus operated Action Providers the ``action`` subcommands
@@ -27,7 +24,7 @@ List of Globus Operated Action Providers
 HelloWorld
 ----------
 
-URL: `<https://actions.globus.org/hello_world>`_
+Action URL: `<https://actions.globus.org/hello_world>`_
 
 Scope: ``https://auth.globus.org/scopes/actions.globus.org/hello_world``
 
@@ -55,7 +52,7 @@ status will become ``SUCCEEDED``.
 Globus Transfer - Transfer Data
 -------------------------------
 
-URL: `<https://actions.globus.org/transfer/transfer>`_
+Action URL: `<https://actions.globus.org/transfer/transfer>`_
 
 Scope: ``https://auth.globus.org/scopes/actions.globus.org/transfer/transfer``
 
@@ -80,7 +77,7 @@ Globus Transfer API.
 Globus Transfer - Delete Data
 -----------------------------
 
-URL: `<https://actions.globus.org/transfer/delete>`_
+Action URL: `<https://actions.globus.org/transfer/delete>`_
 
 Scope: ``https://auth.globus.org/scopes/actions.globus.org/transfer/delete``
 
@@ -96,7 +93,7 @@ directly from the Task status in the Globus Transfer API.
 Globus Transfer - Set/Manage Permissions
 ----------------------------------------
 
-URL: `<https://actions.globus.org/transfer/set_permission>`_
+Action URL: `<https://actions.globus.org/transfer/set_permission>`_
 
 Scope: ``https://auth.globus.org/scopes/actions.globus.org/transfer/set_permission``
 
@@ -127,7 +124,7 @@ returning the Transfer API result.
 Globus Transfer - List Directory Contents
 -----------------------------------------
 
-URL: `<https://actions.globus.org/transfer/ls>`_
+Action URL: `<https://actions.globus.org/transfer/ls>`_
 
 Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/transfer_ls``
 
@@ -149,7 +146,7 @@ Additionally, it adds two features not found in the base Globus Transfer List Di
 Globus Transfer - Make Directory
 --------------------------------
 
-URL: `<https://actions.globus.org/transfer/mkdir>`_
+Action URL: `<https://actions.globus.org/transfer/mkdir>`_
 
 Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/transfer_mkdir``
 
@@ -166,7 +163,7 @@ to create a new directory on an endpoint. The input is simply the id for endpoin
 Globus Transfer - Get Collection Information
 --------------------------------------------
 
-URL: `<https://actions.globus.org/transfer/collection_info>`_
+Action URL: `<https://actions.globus.org/transfer/collection_info>`_
 
 Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/transfer_collection_info``
 
@@ -178,7 +175,7 @@ to get information about a Globus Collection. The information returned is the sa
 Globus Search - Ingest
 ----------------------
 
-URL: `<https://actions.globus.org/search/ingest>`_
+Action URL: `<https://actions.globus.org/search/ingest>`_
 
 Scope: ``https://auth.globus.org/scopes/actions.globus.org/search/ingest``
 
@@ -204,7 +201,7 @@ not support cancellation of its Actions.
 Globus Search - Delete
 ----------------------
 
-URL: `<https://actions.globus.org/search/delete>`_
+Action URL: `<https://actions.globus.org/search/delete>`_
 
 Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/search_delete``
 
@@ -238,7 +235,7 @@ of its Actions.
 Send Notification - Email
 -------------------------
 
-URL: `<https://actions.globus.org/notification/notify>`_
+Action URL: `<https://actions.globus.org/notification/notify>`_
 
 Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/notification_notify``
 
@@ -277,7 +274,7 @@ improper recipient address.
 Wait for User Option Selection
 ------------------------------
 
-URL: `<https://actions.globus.org/weboption/wait_for_option>`_
+Action URL: `<https://actions.globus.org/weboption/wait_for_option>`_
 
 Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/weboption_wait_for_option``
 
@@ -347,7 +344,7 @@ Simple Expression Evaluation
     Simple Expression Evaluation Action Provider described here is not needed
     and expressions defined on Action definitions within a Flow are preferred.
 
-URL: `<https://actions.globus.org/expression_eval>`_
+Action URL: `<https://actions.globus.org/expression_eval>`_
 
 Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/expression``
 
@@ -386,7 +383,7 @@ result in previous results being over-written.
 Datacite DOI Minting
 --------------------
 
-URL: `<https://actions.globus.org/datacite/mint/basic_auth>`_
+Action URL: `<https://actions.globus.org/datacite/mint/basic_auth>`_
 
 Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/datacite_mint_basic_auth_action_all``
 
@@ -413,7 +410,7 @@ should be used in the Datacite test service or the production service.
 HTTP requests
 -------------
 
-URL: `<https://actions.globus.org/http>`_
+Action URL: `<https://actions.globus.org/http>`_
 
 Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/http``
 

--- a/docs/source/globus_action_providers.rst
+++ b/docs/source/globus_action_providers.rst
@@ -432,6 +432,7 @@ Here is an example of the simplest functional input document:
 A single HTTP request can be customized in four key ways:
 
 *   HTTP method
+*   HTTP URL
 *   Content submission
 *   URL customization
 
@@ -748,6 +749,21 @@ Errors: HTTP request or response failures
     or if the server doesn't respond within 5 (five) seconds.
 
     The text of the failure is included in the error message and can help troubleshoot why the request failed.
+
+``HTTP_RESPONSE_TOO_LARGE``
+    The HTTP response was larger than 128KB.
+
+    If you encounter this error when submitting a request for a large number of results
+    then you may be able to overcome this error by filtering results in some way
+    or restricting the amount of information returned per result.
+
+``HTTP_RESPONSE_TIMEOUT``
+    The HTTP response stayed open for longer than 10 (ten) total seconds.
+
+    This error differs from ``HTTP_REQUEST_FAILED`` in that the target URL's server responded.
+    However, the server failed to transfer its results with 10 (ten) seconds.
+    It may be that the target URL is triggering a computationally-expensive operation.
+    In this situation you will need to find a way to reduce the delay in the target URL's response.
 
 ``HTTP_RESPONSE_NOT_JSON``
     At this time, all HTTP requests must return valid JSON.

--- a/docs/source/globus_action_providers.rst
+++ b/docs/source/globus_action_providers.rst
@@ -436,14 +436,6 @@ A single HTTP request can be customized in four key ways:
 *   Content submission
 *   URL customization
 
-..  note::
-
-    The JSON schema that authoritatively describes the accepted keys and values can be retrieved using this command:
-
-    ..  code-block:: text
-
-        globus-automate action introspect --action-url https://actions.globus.org/http
-
 
 HTTP method
 ...........
@@ -667,11 +659,7 @@ Errors: JSON schema validation
 ..............................
 
 Input documents will be validated against the HTTP action provider JSON schema.
-You can get an authoritative copy of the JSON schema by running this command:
-
-..  code-block:: text
-
-    globus-automate action introspect --action-url https://actions.globus.org/http
+The schema can be authoritatively retrieved using the introspection instructions at the top of this document.
 
 If the JSON schema validation fails the HTTP provider will return a JSON document with a list of errors.
 For example, if the ``method`` is not one of the supported values you will see an error like this:

--- a/docs/source/globus_action_providers.rst
+++ b/docs/source/globus_action_providers.rst
@@ -463,6 +463,22 @@ and DELETE requests erase existing information.
     }
 
 
+HTTP URL
+........
+
+..  csv-table::
+
+    "Key name", "``url``"
+    "Value type", "string"
+    "Required", "True"
+    "Default", "*None*"
+
+The ``url`` key indicates the target URL that will be accessed by the HTTP request.
+
+It can be manipulated and augmented dynamically using query parameters and URL substitution identifiers, which are documented below.
+
+
+
 HTTP timeout
 ............
 


### PR DESCRIPTION
This branch adds documentation for the upcoming HTTP action provider, including:

* The URL and scope
* Complete documentation of all input document keys and values
* Examples of usage
* Documentation of the errors that may be returned by the HTTP action provider, including suggestions for how to resolve the errors.

[sc-11704]