### PR TITLE
Allow more value types when merging keyword parameter aliases

### DIFF
--- a/changelog.d/20211123_092348_kurtmckee_merge_parameter_aliases_better.rst
+++ b/changelog.d/20211123_092348_kurtmckee_merge_parameter_aliases_better.rst
@@ -1,0 +1,6 @@
+Bugfixes
+--------
+
+-   Support strings (and tuples/sets containing strings) as argument values
+    when running, deploying, or updating an action or a flow and specifying
+    a keyword argument alias like ``visible_to`` or ``runnable_by``.

--- a/globus_automate_client/action_client.py
+++ b/globus_automate_client/action_client.py
@@ -10,7 +10,7 @@ from globus_sdk import (
 )
 from globus_sdk import BaseClient
 
-from .helpers import merge_lists
+from .helpers import merge_keywords
 
 _ActionClient = TypeVar("_ActionClient", bound="ActionClient")
 
@@ -96,8 +96,8 @@ class ActionClient(BaseClient):
         body = {
             "request_id": str(request_id),
             "body": body,
-            "monitor_by": merge_lists(monitor_by, kwargs, "run_monitors"),
-            "manage_by": merge_lists(manage_by, kwargs, "run_managers"),
+            "monitor_by": merge_keywords(monitor_by, kwargs, "run_monitors"),
+            "manage_by": merge_keywords(manage_by, kwargs, "run_managers"),
             "label": label,
         }
         # Remove None items from the temp_body

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -27,7 +27,7 @@ from jsonschema import Draft7Validator
 
 from globus_automate_client import ActionClient
 
-from .helpers import merge_lists
+from .helpers import merge_keywords
 
 PROD_FLOWS_BASE_URL = "https://flows.globus.org"
 
@@ -296,13 +296,13 @@ class FlowsClient(BaseClient):
         temp_body["description"] = description
         temp_body["keywords"] = keywords
         # We'll accept some aliases for the role lists passed in kwargs
-        temp_body["flow_viewers"] = merge_lists(
+        temp_body["flow_viewers"] = merge_keywords(
             flow_viewers, kwargs, "visible_to", "viewers"
         )
-        temp_body["flow_starters"] = merge_lists(
+        temp_body["flow_starters"] = merge_keywords(
             flow_starters, kwargs, "runnable_by", "starters"
         )
-        temp_body["flow_administrators"] = merge_lists(
+        temp_body["flow_administrators"] = merge_keywords(
             flow_administrators, kwargs, "administered_by", "administrators"
         )
         temp_body["subscription_id"] = subscription_id
@@ -388,11 +388,11 @@ class FlowsClient(BaseClient):
             "subtitle": subtitle,
             "description": description,
             "keywords": keywords,
-            "flow_viewers": merge_lists(flow_viewers, kwargs, "visible_to", "viewers"),
-            "flow_starters": merge_lists(
+            "flow_viewers": merge_keywords(flow_viewers, kwargs, "visible_to", "viewers"),
+            "flow_starters": merge_keywords(
                 flow_starters, kwargs, "runnable_by", "starters"
             ),
-            "flow_administrators": merge_lists(
+            "flow_administrators": merge_keywords(
                 flow_administrators, kwargs, "administered_by", "administrators"
             ),
             "subscription_id": subscription_id,
@@ -577,8 +577,8 @@ class FlowsClient(BaseClient):
         # Merge monitors and managers with aliases.
         # If either list is empty it will be replaced with None
         # to prevent empty lists from appearing in the JSON request.
-        run_monitors = merge_lists(run_monitors, kwargs, "monitor_by") or None
-        run_managers = merge_lists(run_managers, kwargs, "manage_by") or None
+        run_monitors = merge_keywords(run_monitors, kwargs, "monitor_by") or None
+        run_managers = merge_keywords(run_managers, kwargs, "manage_by") or None
 
         if dry_run:
             path = flow_url + "/dry-run"

--- a/globus_automate_client/helpers.py
+++ b/globus_automate_client/helpers.py
@@ -31,7 +31,7 @@ def merge_keywords(
 
     ..  code-block:: python
 
-        all_names = consume_keywords(names, kwargs, "pseudonyms", "nicknames")
+        all_names = merge_keywords(names, kwargs, "pseudonyms", "nicknames")
 
     """
 

--- a/globus_automate_client/helpers.py
+++ b/globus_automate_client/helpers.py
@@ -1,52 +1,59 @@
-import typing as t
+from typing import Dict, Iterable, List, Optional, Set, Union
 
 
-def merge_lists(*args, pop_dict_lists: bool = True) -> t.Optional[t.List]:
-    """Merge/concatenate a set of lists passed in the args. If any value in the args list is
-    None, it is ignored. If all values in the args list are None (or the args list is
-    empty) None is returned.
+def merge_keywords(
+    base: Optional[Iterable[str]],
+    kwargs: Dict[str, Union[str, Iterable[str]]],
+    *keywords: str,
+) -> Optional[List[str]]:
+    """Merge all given keyword parameter aliases and deduplicate the values.
 
-    If an arg encountered in the list is a dict rather than a list, all subsequent values
-    in the args list will be treated as keys into the dict and the value for those keys
-    in the dict will be treated as lists to be concatenated as with the other lists
-    passed in the args prior to the dict.
+    ..  warning::
 
-    Intended use is for the case of setting up a merged list from a function that has
-    arguments as lists and potential (alias) kwargs that need to be merged. In such a
-    case, this could be called as:
+        This function has a side-effect. It deliberately modifies *kwargs* in-place.
+        Any keyword alias that exists in *kwargs* will be removed from *kwargs*.
 
-    merge_lists(list_arg, kwargs, "alias_list_name")
+    If an alias key exists in *kwargs* and has a value other than None
+    then it will be included in the final result that is returned.
 
-    which would yield a list containing the list_args merged with any potential
-    alias_list_name from the kwargs.
+    If *base* is None and all found aliases have a value of None,
+    then None will be returned.
 
-    Merging also includes performing de-duplication of values.
+    For example, given a function with the following call signature:
 
-    If pop_dict_lists is True (the default) lists found in the dict will also be removed
-    from the dict.
+    ..  code-block:: python
+
+        def example(names=None, **kwargs):
+            pass
+
+    It is possible to quickly add support for additional parameter names
+    so that users can call the function with alternative keyword parameters:
+
+    ..  code-block:: python
+
+        all_names = consume_keywords(names, kwargs, "pseudonyms", "nicknames")
 
     """
 
-    ret_set: t.Optional[t.Set] = None
-    dict_val: t.Optional[t.Dict] = None
-    for arg in args:
-        list_for_arg: t.Optional[t.List] = None
-        if isinstance(arg, dict):
-            dict_val = arg
-        elif dict_val is not None and arg in dict_val:
-            list_for_arg = dict_val.get(arg)
-            if pop_dict_lists:
-                dict_val.pop(arg, None)
-            if not isinstance(list_for_arg, list):
-                list_for_arg = None
-        elif isinstance(arg, list):
-            list_for_arg = arg
-        if list_for_arg is not None:
-            if ret_set is None:
-                ret_set = set(list_for_arg)
-            else:
-                ret_set.update(list_for_arg)
-    if ret_set is None:
+    result: Optional[Set[str]] = None
+    if base:
+        result = set(base)
+
+    for keyword in keywords:
+        # Consume the keyword alias.
+        # NOTE: .pop() is a destructive operation with a deliberate side-effect.
+        value = kwargs.pop(keyword, None)
+        if value is None:
+            continue
+
+        # Update the final result.
+        if result is None:
+            result = set()
+        if isinstance(value, str):
+            result.add(value)
+        else:
+            result |= set(value)
+
+    if result is None:
         return None
-    else:
-        return list(ret_set)
+    return list(result)


### PR DESCRIPTION
This change simplifies the code in the `merge_aliases()` function and allows it to merge additional value types, like strings and tuples of strings.

# Changelog

Bugfixes
--------

-   Support strings (and tuples/sets containing strings) as argument values
    when running, deploying, or updating an action or a flow and specifying
    a keyword argument alias like ``visible_to`` or ``runnable_by``.



[sc-11808]