### PR TITLE
CI/CD/Docs updates to refer to main branch

### DIFF
--- a/.github/workflows/has_changelog.yaml
+++ b/.github/workflows/has_changelog.yaml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:  # do a deep fetch to allow merge-base and diff
+        with: # do a deep fetch to allow merge-base and diff
           fetch-depth: 0
       - name: check PR adds a news file
         run: |
-          news_files="$(git diff --name-only "$(git merge-base origin/master "$GITHUB_SHA")" "$GITHUB_SHA" -- changelog.d/*.rst)"
+          news_files="$(git diff --name-only "$(git merge-base origin/main "$GITHUB_SHA")" "$GITHUB_SHA" -- changelog.d/*.rst)"
           if [ -n "$news_files" ]; then
             echo "Saw new files. changelog.d:"
             echo "$news_files"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Unreleased changes
 
 Unreleased changes are documented in files in the `changelog.d`_ directory.
 
-..  _changelog.d: https://github.com/globus/globus-automate-client/tree/master/changelog.d
+..  _changelog.d: https://github.com/globus/globus-automate-client/tree/main/changelog.d
 
 ..  scriv-insert-here
 
@@ -240,7 +240,7 @@ Documentation
 -   Improves documentation around manually creating authorizers and how to use them to create ``ActionClients`` and ``FlowsClient``:
     https://globus-automate-client.readthedocs.io/en/latest/python_sdk.html#sdk-the-hard-way
 -   Adds examples for Flow definitions as YAML:
-    https://github.com/globus/globus-automate-client/tree/master/examples/flows/hello-world-yaml
+    https://github.com/globus/globus-automate-client/tree/main/examples/flows/hello-world-yaml
 
 0.10.5 — 2020-12-11
 ===================

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Testing, Development, and Contributing
 --------------------------------------
 
 Go to the
-`CONTRIBUTING <https://github.com/globus/globus-automate-client/blob/master/CONTRIBUTING.adoc>`_
+`CONTRIBUTING <https://github.com/globus/globus-automate-client/blob/main/CONTRIBUTING.adoc>`_
 guide for detail.
 
 Links

--- a/docs/source/example_flows.rst
+++ b/docs/source/example_flows.rst
@@ -2,4 +2,4 @@ Example Flows
 =============
 
 For examples of Flows, input schemas, and inputs see the `Globus Automate Client
-repository's examples <https://github.com/globus/globus-automate-client/tree/master/examples/flows>`_
+repository's examples <https://github.com/globus/globus-automate-client/tree/main/examples/flows>`_


### PR DESCRIPTION
Client side updates to match the `master`->`main` rename as well as the the new `production` branch usage.

The commands to update the repo locally are extremely the same:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```
