### PR TITLE
Allows workflow to be reused

### DIFF
--- a/.github/workflows/has_changelog.yaml
+++ b/.github/workflows/has_changelog.yaml
@@ -1,6 +1,7 @@
 name: has_changelog
 on:
   - pull_request
+  - workflow_call
 
 jobs:
   check_has_news_in_changelog_dir:


### PR DESCRIPTION
This PR adds a the `workflow` call event as a trigger which is necessary to allow other Github Action workflows to use the workflow. This is a stop gap solution to share the enforce changelog fragment behavior across our repositories until something more permanent gets set up.