### PR TITLE
Adds an input schema sample Flow definition

### DIFF
--- a/changelog.d/20220107_173705_uriel_add_example_flow_input_schema.rst
+++ b/changelog.d/20220107_173705_uriel_add_example_flow_input_schema.rst
@@ -1,0 +1,5 @@
+Documentation
+-------------
+
+- Adds an input schema for the example single-transfer Flow definition.
+

--- a/examples/flows/single-transfer/input-schema.json
+++ b/examples/flows/single-transfer/input-schema.json
@@ -1,0 +1,31 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "source_endpoint_id",
+        "destination_endpoint_id",
+        "transfer_items"
+    ],
+    "properties": {
+        "source_endpoint_id": {
+            "type": "string"
+        },
+        "destination_endpoint_id": {
+            "type": "string"
+        },
+        "transfer_items": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "source_path": {
+                        "type": "string"
+                    },
+                    "destination_path": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/flows/single-transfer/input-schema.json
+++ b/examples/flows/single-transfer/input-schema.json
@@ -17,12 +17,20 @@
             "type": "array",
             "items": {
                 "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "source_path",
+                    "destination_path"
+                ],
                 "properties": {
                     "source_path": {
                         "type": "string"
                     },
                     "destination_path": {
                         "type": "string"
+                    },
+                    "recursive": {
+                        "type": "boolean"
                     }
                 }
             }


### PR DESCRIPTION
The Single Transfer Flow definition was missing an input schema. This PR adds its schema.
