### PR TITLE
Flow definition validation via Pydantic

### DIFF
--- a/changelog.d/20220110_180812_uriel_pydantic_flow_def_validation.rst
+++ b/changelog.d/20220110_180812_uriel_pydantic_flow_def_validation.rst
@@ -1,0 +1,18 @@
+Features
+--------
+
+- Performs richer Flow validation using pydantic based models to catch Flow
+  definition errors before it gets deployed to the Flows service and Step
+  Functions.
+
+..
+.. Bugfixes
+.. --------
+..
+.. - A bullet item for the Bugfixes category.
+..
+.. Documentation
+.. -------------
+..
+.. - A bullet item for the Documentation category.
+..

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,8 @@ autodoc_mock_imports = [
     "click",
     "typer",
     "rich",
+    "pydantic",
+    "typing_extensions",
 ]
 autodoc_typehints = "description"
 

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -44,9 +44,9 @@ from globus_automate_client.cli.rich_rendering import live_content
 from globus_automate_client.client_helpers import create_flows_client
 from globus_automate_client.flows_client import (
     RUN_STATUS_SCOPE,
-    FlowValidationError,
     validate_flow_definition,
 )
+from globus_automate_client.models import FlowValidationError
 
 app = typer.Typer(short_help="Manage Globus Automate Flows")
 

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -14,7 +14,6 @@ from typing import (
 )
 from urllib.parse import quote, urljoin
 
-import pydantic
 from globus_sdk import (
     AccessTokenAuthorizer,
     BaseClient,

--- a/globus_automate_client/models.py
+++ b/globus_automate_client/models.py
@@ -17,13 +17,13 @@ from pydantic import (
 FlowValidationError
 
 
-def enforce_jsonpath(v: t.Optional[str]):
+def enforce_jsonpath(v: t.Optional[str]) -> t.Optional[str]:
     if v is not None and not v.startswith("$."):
         raise ValueError(f'"{v}" must be a JSONPath and start with "$."')
     return v
 
 
-def check_jsonpath_syntax_in_dict(item: t.Optional[dict]):
+def check_jsonpath_syntax_in_dict(item: t.Optional[dict]) -> t.Optional[dict]:
     if item is None:
         return item
 
@@ -50,6 +50,9 @@ class Catchers(BaseModel):
     ErrorEquals: t.List[str] = Field(..., min_items=1)
     Next: str
     ResultPath: t.Optional[str]
+
+    class Config:
+        extra = Extra.forbid
 
     _enforce_jsonpath = validator("ResultPath", allow_reuse=True)(enforce_jsonpath)
 
@@ -146,6 +149,9 @@ class BooleanExpression(BaseModel):
         None, min_items=1
     )
     Not: t.Optional[t.Union[DataTestExpression, "BooleanExpression"]] = None
+
+    class Config:
+        extra = Extra.forbid
 
     @root_validator(skip_on_failure=True)
     def validate_only_one_boolean_choice_rule_set(cls, values):
@@ -328,6 +334,9 @@ class FlowDefinition(BaseModel):
     States: t.Dict[str, FlowState]
     Comment: t.Optional[str]
 
+    class Config:
+        extra = Extra.forbid
+
     @validator("States")
     def validate_states(cls, v):
         if len(v) < 1:
@@ -346,13 +355,13 @@ class FlowDefinition(BaseModel):
 
     @root_validator(skip_on_failure=True)
     def validate_start_at_is_a_state(cls, values):
-        states, start_at = values.get("States"), values.get("StartAt")
-        if states and start_at not in states:
+        states, start_at = values.get("States", {}), values.get("StartAt", "")
+        if start_at not in states:
             raise ValueError(f'StartAt state "{start_at}" is not defined in States')
         return values
 
     @root_validator(skip_on_failure=True)
-    def validate_all_transtion_states_exist(cls, values):
+    def validate_all_transition_states_exist(cls, values):
         states = values.get("States", {})
         defined_states = set(states.keys())
         referenced_states = {values["StartAt"]}
@@ -382,7 +391,7 @@ class FlowDefinition(BaseModel):
         unreferenced_states = defined_states - referenced_states
         if undefined_states:
             raise ValueError(
-                f'Flow definition contained a reference to unknown state(s): {",".join(undefined_states)}'
+                f'Flow definition contained a reference to unknown state(s): {", ".join(undefined_states)}'
             )
         if unreferenced_states:
             raise ValueError(

--- a/globus_automate_client/models.py
+++ b/globus_automate_client/models.py
@@ -14,6 +14,8 @@ from pydantic import (
     validator,
 )
 
+FlowValidationError
+
 
 def enforce_jsonpath(v: t.Optional[str]):
     if v is not None and not v.startswith("$."):

--- a/globus_automate_client/models.py
+++ b/globus_automate_client/models.py
@@ -1,0 +1,387 @@
+import datetime
+import enum
+import typing as t
+
+import typing_extensions as te
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    Extra,
+    Field,
+    StrictBool,
+    ValidationError as FlowValidationError,
+    root_validator,
+    validator,
+)
+
+
+def enforce_jsonpath(v: t.Optional[str]):
+    if v is not None and not v.startswith("$."):
+        raise ValueError(f'"{v}" must be a JSONPath and start with "$."')
+    return v
+
+
+def check_jsonpath_syntax_in_dict(item: t.Optional[dict]):
+    if item is None:
+        return item
+
+    for k, v in item.items():
+        if k.endswith(".$") and (not isinstance(v, str) or not v.startswith("$.")):
+            raise ValueError(
+                f'Key "{k}" indicates its value will be a JSONPath, however its value "{v}" is not a JSONPath'
+            )
+        elif not k.endswith(".$") and (isinstance(v, str) and v.startswith("$.")):
+            raise ValueError(
+                f'Value "{v}" is a JSONPath, however its key "{k}" does not indicate a JSONPath'
+            )
+        elif isinstance(v, dict):
+            check_jsonpath_syntax_in_dict(v)
+    return item
+
+
+class StateType(str, enum.Enum):
+    Pass = "Pass"
+    Action = "Action"
+    Wait = "Wait"
+    Choice = "Choice"
+    ExpressionEval = "ExpressionEval"
+    Fail = "Fail"
+
+
+class Catchers(BaseModel):
+    ErrorEquals: t.List[str] = Field(..., min_items=1)
+    Next: str
+    ResultPath: t.Optional[str]
+
+    _enforce_jsonpath = validator("ResultPath", allow_reuse=True)(enforce_jsonpath)
+
+
+class ChoiceRule(BaseModel):
+    Variable: str
+    StringEquals: t.Optional[str]
+    StringEqualsPath: t.Optional[str]
+    StringLessThan: t.Optional[str]
+    StringLessThanPath: t.Optional[str]
+    StringGreaterThan: t.Optional[str]
+    StringGreaterThanPath: t.Optional[str]
+    StringLessThanEquals: t.Optional[str]
+    StringLessThanEqualsPath: t.Optional[str]
+    StringGreaterThanEquals: t.Optional[str]
+    StringGreaterThanEqualsPath: t.Optional[str]
+    StringMatches: t.Optional[str]
+    NumericEquals: t.Optional[str]
+    NumericEqualsPath: t.Optional[str]
+    NumericLessThan: t.Optional[str]
+    NumericLessThanPath: t.Optional[str]
+    NumericGreaterThan: t.Optional[str]
+    NumericGreaterThanPath: t.Optional[str]
+    NumericLessThanEquals: t.Optional[str]
+    NumericLessThanEqualsPath: t.Optional[str]
+    NumericGreaterThanEquals: t.Optional[str]
+    NumericGreaterThanEqualsPath: t.Optional[str]
+    BooleanEquals: t.Optional[str]
+    BooleanEqualsPath: t.Optional[str]
+    TimestampEquals: t.Optional[str]
+    TimestampEqualsPath: t.Optional[str]
+    TimestampLessThan: t.Optional[str]
+    TimestampLessThanPath: t.Optional[str]
+    TimestampGreaterThan: t.Optional[str]
+    TimestampGreaterThanPath: t.Optional[str]
+    TimestampLessThanEquals: t.Optional[str]
+    TimestampLessThanEqualsPath: t.Optional[str]
+    TimestampGreaterThanEquals: t.Optional[str]
+    TimestampGreaterThanEqualsPath: t.Optional[str]
+    IsNull: t.Optional[str]
+    IsPresent: t.Optional[str]
+    IsNumeric: t.Optional[str]
+    IsString: t.Optional[str]
+    IsBoolean: t.Optional[str]
+    IsTimestamp: t.Optional[str]
+
+    class Config:
+        extra = Extra.forbid
+
+    _enforce_jsonpath = validator(
+        "Variable",
+        "StringEqualsPath",
+        "StringLessThanPath",
+        "StringGreaterThanPath",
+        "StringLessThanEqualsPath",
+        "StringGreaterThanEqualsPath",
+        "NumericEqualsPath",
+        "NumericLessThanPath",
+        "NumericGreaterThanPath",
+        "NumericLessThanEqualsPath",
+        "NumericGreaterThanEqualsPath",
+        "BooleanEqualsPath",
+        "TimestampEqualsPath",
+        "TimestampLessThanPath",
+        "TimestampGreaterThanPath",
+        "TimestampLessThanEqualsPath",
+        "TimestampGreaterThanEqualsPath",
+        allow_reuse=True,
+    )(enforce_jsonpath)
+
+    @root_validator(skip_on_failure=True)
+    def validate_only_one_rule_is_set(cls, values):
+        set_fields = {
+            k
+            for k, v in values.items()
+            if k not in {"Variable", "Next"} and v is not None
+        }
+        if len(set_fields) != 1:
+            raise ValueError(
+                f'A "ChoiceRule" may only contain one expression. Found {", ".join(set_fields)}'
+            )
+        return values
+
+
+class DataTestExpressionChoiceRule(ChoiceRule):
+    Next: str
+
+
+class BooleanExpressionChoiceRule(BaseModel):
+    """
+    A Boolean Expression is a JSON object which contains a field named "And",
+    "Or", or "Not". If the field name is "And" or "Or", the value MUST be an
+    non-empty object array of Choice Rules, which MUST NOT contain "Next"
+    fields; the interpreter processes the array elements in order, performing
+    the boolean evaluations in the expected fashion, ceasing array processing
+    when the boolean value has been unambiguously determined.
+
+    The value of a Boolean Expression containing a "Not" field MUST be a single
+    Choice Rule, that MUST NOT contain a "Next" field; it returns the inverse
+    of the boolean to which the Choice Rule evaluates.
+    """
+
+    And: t.Optional[t.List[ChoiceRule]] = Field(None, min_items=1)
+    Or: t.Optional[t.List[ChoiceRule]] = Field(None, min_items=1)
+    Not: t.Optional[ChoiceRule] = None
+    Next: str
+
+    @root_validator(skip_on_failure=True)
+    def validate_only_one_boolean_choice_rule_set(cls, values):
+        set_fields = {
+            k for k, v in values.items() if k not in {"Next"} and v is not None
+        }
+        if len(set_fields) == 0:
+            raise ValueError(
+                'One of "And", "Or", or "Not" must be specified in a BooleanExpression'
+            )
+        return values
+
+
+class ChoiceState(BaseModel):
+    Type: te.Literal[StateType.Choice]
+    Comment: t.Optional[str] = None
+    Choices: t.List[
+        t.Union[DataTestExpressionChoiceRule, BooleanExpressionChoiceRule]
+    ] = Field(..., min_items=1)
+    Default: t.Optional[str]
+
+    class Config:
+        extra = Extra.forbid
+
+
+class NextOrEndState(BaseModel):
+    Next: t.Optional[str] = None
+    End: StrictBool = False
+
+    @root_validator
+    def validate_mutually_exclusive_fields(cls, values):
+        if values.get("Next") and values.get("End"):
+            raise ValueError('"Next" and "End" are mutually exclusive')
+        if values.get("Next") is None and not values.get("End", False):
+            raise ValueError('Either "Next" or "End" are required')
+        return values
+
+
+class ActionState(NextOrEndState):
+    Type: te.Literal[StateType.Action]
+    Comment: t.Optional[str] = None
+    ActionUrl: AnyHttpUrl
+    ActionScope: t.Optional[str] = None
+    Parameters: t.Optional[t.Dict[str, t.Any]] = None
+    RunAs: str = "User"
+    ExceptionOnActionFailure: StrictBool = True
+    Catch: t.Optional[t.List[Catchers]] = None
+    WaitTime: int = 300
+    InputPath: t.Optional[str] = None
+    ResultPath: t.Optional[str] = None
+
+    class Config:
+        extra = Extra.forbid
+
+    _enforce_jsonpath = validator("InputPath", "ResultPath", allow_reuse=True)(
+        enforce_jsonpath
+    )
+    _check_jsonpath_syntax_in_dict = validator("Parameters", allow_reuse=True)(
+        check_jsonpath_syntax_in_dict
+    )
+
+    @root_validator
+    def validate_mutually_exclusive_fields(cls, values):
+        fields = ["InputPath", "Parameters"]
+        set_fields = {f: values.get(f) for f in fields if values.get(f) is not None}
+        if len(set_fields) > 1:
+            raise ValueError(
+                f"Only one of these fields may be set: {set_fields.keys()}"
+            )
+        if len(set_fields) == 0:
+            raise ValueError(f"At least one field must be set: {fields}")
+
+        return values
+
+
+class ExpressionEvalState(NextOrEndState):
+    Type: te.Literal[StateType.ExpressionEval]
+    Comment: t.Optional[str] = None
+    Parameters: t.Optional[dict] = None
+    ResultPath: t.Optional[str] = None
+
+    class Config:
+        extra = Extra.forbid
+
+    _enforce_jsonpath = validator("ResultPath", allow_reuse=True)(enforce_jsonpath)
+    _check_jsonpath_syntax_in_dict = validator("Parameters", allow_reuse=True)(
+        check_jsonpath_syntax_in_dict
+    )
+
+
+class FailState(BaseModel):
+    Type: te.Literal[StateType.Fail]
+    Comment: t.Optional[str] = None
+    Cause: t.Optional[str] = None
+    Error: t.Optional[str] = None
+
+    class Config:
+        extra = Extra.forbid
+
+
+class PassState(NextOrEndState):
+    Type: te.Literal[StateType.Pass]
+    Comment: t.Optional[str] = None
+    Parameters: t.Optional[t.Dict[str, t.Any]] = None
+    InputPath: t.Optional[str] = None
+    Result: t.Optional[dict] = None
+    ResultPath: t.Optional[str] = None
+    # Not supported by Flows
+    # OutputPath: t.Optional[str] = None
+
+    class Config:
+        extra = Extra.forbid
+
+    _enforce_jsonpath = validator(
+        "InputPath", "Result", "ResultPath", allow_reuse=True
+    )(enforce_jsonpath)
+    _check_jsonpath_syntax_in_dict = validator("Parameters", allow_reuse=True)(
+        check_jsonpath_syntax_in_dict
+    )
+
+
+class WaitState(NextOrEndState):
+    Type: te.Literal[StateType.Wait]
+    Comment: t.Optional[str] = None
+    InputPath: t.Optional[str] = None
+    OutputPath: t.Optional[str] = None
+    Seconds: t.Optional[int] = None
+    Timestamp: t.Optional[datetime.datetime] = None
+    SecondsPath: t.Optional[str] = None
+    TimestampPath: t.Optional[str] = None
+
+    _enforce_jsonpath = validator(
+        "InputPath", "OutputPath", "SecondsPath", "TimestampPath", allow_reuse=True
+    )(enforce_jsonpath)
+
+    class Config:
+        extra = Extra.forbid
+
+    @root_validator(skip_on_failure=True)
+    def validate_mutually_exclusive_fields(cls, values):
+        fields = ["Seconds", "Timestamp", "SecondsPath", "TimestampPath"]
+        set_fields = {f: values.get(f) for f in fields if values.get(f) is not None}
+        if len(set_fields) > 1:
+            raise ValueError(
+                f"Only one of these fields may be set: {set_fields.keys()}"
+            )
+        if len(set_fields) == 0:
+            raise ValueError(f"At least one field must be set: {fields}")
+
+        return values
+
+
+FlowState = te.Annotated[
+    t.Union[
+        PassState, WaitState, ActionState, FailState, ChoiceState, ExpressionEvalState
+    ],
+    Field(discriminator="Type"),
+]
+
+
+class FlowDefinition(BaseModel):
+    StartAt: str
+    States: t.Dict[str, FlowState]
+    Comment: t.Optional[str]
+
+    @validator("States")
+    def validate_states(cls, v):
+        if len(v) < 1:
+            raise ValueError('At least one "State" is required')
+
+        invalid_state_names = [
+            state_name
+            for state_name in v.keys()
+            if len(state_name) > 128 or len(state_name) == 0
+        ]
+        if invalid_state_names:
+            raise ValueError(
+                f"The following states have invalid names: {', '.join(invalid_state_names)}"
+            )
+        return v
+
+    @root_validator(skip_on_failure=True)
+    def validate_start_at_is_a_state(cls, values):
+        states, start_at = values.get("States"), values.get("StartAt")
+        if states and start_at not in states:
+            raise ValueError(f'StartAt state "{start_at}" is not defined in States')
+        return values
+
+    @root_validator(skip_on_failure=True)
+    def validate_all_transtion_states_exist(cls, values):
+        states = values.get("States", {})
+        defined_states = set(states.keys())
+        referenced_states = {values["StartAt"]}
+
+        for _, state in states.items():
+            if state.Type not in {StateType.Choice, StateType.Fail}:
+                # Ensure that all state's with a Next property have a valid transition
+                next_state = state.Next
+                if next_state is not None:
+                    referenced_states.add(next_state)
+
+            # Ensure that the Catch conditions in an Action state refer to a
+            # valid transition
+            if state.Type == StateType.Action:
+                if state.Catch:
+                    for catcher in state.Catch:
+                        referenced_states.add(catcher.Next)
+
+            # Ensure that the choice state rules have valid transitions
+            elif state.Type == StateType.Choice:
+                if state.Default:
+                    referenced_states.add(state.Default)
+                for choice in state.Choices:
+                    referenced_states.add(choice.Next)
+
+        undefined_states = referenced_states - defined_states
+        unreferenced_states = defined_states - referenced_states
+        if undefined_states:
+            raise ValueError(
+                f'Flow definition contained a reference to unknown state(s): {",".join(undefined_states)}'
+            )
+        if unreferenced_states:
+            raise ValueError(
+                f'Flow definition contained unreachable state(s): {",".join(unreferenced_states)}'
+            )
+
+        return values

--- a/globus_automate_client/models.py
+++ b/globus_automate_client/models.py
@@ -92,12 +92,12 @@ class DataTestExpression(BaseModel):
     TimestampLessThanEqualsPath: t.Optional[str]
     TimestampGreaterThanEquals: t.Optional[str]
     TimestampGreaterThanEqualsPath: t.Optional[str]
-    IsNull: t.Optional[str]
-    IsPresent: t.Optional[str]
-    IsNumeric: t.Optional[str]
-    IsString: t.Optional[str]
-    IsBoolean: t.Optional[str]
-    IsTimestamp: t.Optional[str]
+    IsNull: t.Optional[StrictBool]
+    IsPresent: t.Optional[StrictBool]
+    IsNumeric: t.Optional[StrictBool]
+    IsString: t.Optional[StrictBool]
+    IsBoolean: t.Optional[StrictBool]
+    IsTimestamp: t.Optional[StrictBool]
 
     class Config:
         extra = Extra.forbid

--- a/poetry.lock
+++ b/poetry.lock
@@ -1010,6 +1010,22 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pydantic"
+version = "1.9.0"
+description = "Data validation and settings management using python 3.6 type hinting"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+
+[[package]]
 name = "pyflakes"
 version = "2.3.1"
 description = "passive checker of Python programs"
@@ -2118,6 +2134,43 @@ pycodestyle = [
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+pydantic = [
+    {file = "pydantic-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cb23bcc093697cdea2708baae4f9ba0e972960a835af22560f6ae4e7e47d33f5"},
+    {file = "pydantic-1.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1d5278bd9f0eee04a44c712982343103bba63507480bfd2fc2790fa70cd64cf4"},
+    {file = "pydantic-1.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab624700dc145aa809e6f3ec93fb8e7d0f99d9023b713f6a953637429b437d37"},
+    {file = "pydantic-1.9.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c8d7da6f1c1049eefb718d43d99ad73100c958a5367d30b9321b092771e96c25"},
+    {file = "pydantic-1.9.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3c3b035103bd4e2e4a28da9da7ef2fa47b00ee4a9cf4f1a735214c1bcd05e0f6"},
+    {file = "pydantic-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3011b975c973819883842c5ab925a4e4298dffccf7782c55ec3580ed17dc464c"},
+    {file = "pydantic-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:086254884d10d3ba16da0588604ffdc5aab3f7f09557b998373e885c690dd398"},
+    {file = "pydantic-1.9.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0fe476769acaa7fcddd17cadd172b156b53546ec3614a4d880e5d29ea5fbce65"},
+    {file = "pydantic-1.9.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8e9dcf1ac499679aceedac7e7ca6d8641f0193c591a2d090282aaf8e9445a46"},
+    {file = "pydantic-1.9.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d1e4c28f30e767fd07f2ddc6f74f41f034d1dd6bc526cd59e63a82fe8bb9ef4c"},
+    {file = "pydantic-1.9.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:c86229333cabaaa8c51cf971496f10318c4734cf7b641f08af0a6fbf17ca3054"},
+    {file = "pydantic-1.9.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:c0727bda6e38144d464daec31dff936a82917f431d9c39c39c60a26567eae3ed"},
+    {file = "pydantic-1.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:dee5ef83a76ac31ab0c78c10bd7d5437bfdb6358c95b91f1ba7ff7b76f9996a1"},
+    {file = "pydantic-1.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d9c9bdb3af48e242838f9f6e6127de9be7063aad17b32215ccc36a09c5cf1070"},
+    {file = "pydantic-1.9.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ee7e3209db1e468341ef41fe263eb655f67f5c5a76c924044314e139a1103a2"},
+    {file = "pydantic-1.9.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0b6037175234850ffd094ca77bf60fb54b08b5b22bc85865331dd3bda7a02fa1"},
+    {file = "pydantic-1.9.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b2571db88c636d862b35090ccf92bf24004393f85c8870a37f42d9f23d13e032"},
+    {file = "pydantic-1.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8b5ac0f1c83d31b324e57a273da59197c83d1bb18171e512908fe5dc7278a1d6"},
+    {file = "pydantic-1.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:bbbc94d0c94dd80b3340fc4f04fd4d701f4b038ebad72c39693c794fd3bc2d9d"},
+    {file = "pydantic-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e0896200b6a40197405af18828da49f067c2fa1f821491bc8f5bde241ef3f7d7"},
+    {file = "pydantic-1.9.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7bdfdadb5994b44bd5579cfa7c9b0e1b0e540c952d56f627eb227851cda9db77"},
+    {file = "pydantic-1.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:574936363cd4b9eed8acdd6b80d0143162f2eb654d96cb3a8ee91d3e64bf4cf9"},
+    {file = "pydantic-1.9.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c556695b699f648c58373b542534308922c46a1cda06ea47bc9ca45ef5b39ae6"},
+    {file = "pydantic-1.9.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:f947352c3434e8b937e3aa8f96f47bdfe6d92779e44bb3f41e4c213ba6a32145"},
+    {file = "pydantic-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5e48ef4a8b8c066c4a31409d91d7ca372a774d0212da2787c0d32f8045b1e034"},
+    {file = "pydantic-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:96f240bce182ca7fe045c76bcebfa0b0534a1bf402ed05914a6f1dadff91877f"},
+    {file = "pydantic-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:815ddebb2792efd4bba5488bc8fde09c29e8ca3227d27cf1c6990fc830fd292b"},
+    {file = "pydantic-1.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6c5b77947b9e85a54848343928b597b4f74fc364b70926b3c4441ff52620640c"},
+    {file = "pydantic-1.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c68c3bc88dbda2a6805e9a142ce84782d3930f8fdd9655430d8576315ad97ce"},
+    {file = "pydantic-1.9.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a79330f8571faf71bf93667d3ee054609816f10a259a109a0738dac983b23c3"},
+    {file = "pydantic-1.9.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f5a64b64ddf4c99fe201ac2724daada8595ada0d102ab96d019c1555c2d6441d"},
+    {file = "pydantic-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a733965f1a2b4090a5238d40d983dcd78f3ecea221c7af1497b845a9709c1721"},
+    {file = "pydantic-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cc6a4cb8a118ffec2ca5fcb47afbacb4f16d0ab8b7350ddea5e8ef7bcc53a16"},
+    {file = "pydantic-1.9.0-py3-none-any.whl", hash = "sha256:085ca1de245782e9b46cefcf99deecc67d418737a1fd3f6a4f511344b613a5b3"},
+    {file = "pydantic-1.9.0.tar.gz", hash = "sha256:742645059757a56ecd886faf4ed2441b9c0cd406079c2b4bee51bcc3fbcd510a"},
 ]
 pyflakes = [
     {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ jsonschema = "^3.2.0"
 PyYAML = "^5.3.1"
 rich = "^9.12.2"
 arrow = "^1.1.1"
+pydantic = "^1.9.0"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.9"

--- a/tests/flow_validation/test_action_state.py
+++ b/tests/flow_validation/test_action_state.py
@@ -1,0 +1,339 @@
+import typing as t
+
+import pytest
+
+from globus_automate_client.models import FlowDefinition, FlowValidationError
+
+simple_action_state = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {},
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+action_state_with_catcher = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {},
+            "ResultPath": "$.some_path",
+            "End": True,
+            "ExceptionOnActionFailure": True,
+            "Catch": [
+                {
+                    "ErrorEquals": ["ErrorA", "ErrorB"],
+                    "Next": "TerminalState",
+                }
+            ],
+        },
+        "TerminalState": {"Type": "Fail"},
+    },
+}
+
+action_state_with_multiple_catchers = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {},
+            "ResultPath": "$.some_path",
+            "End": True,
+            "ExceptionOnActionFailure": True,
+            "Catch": [
+                {
+                    "ErrorEquals": ["ErrorA", "ErrorB"],
+                    "Next": "TerminalState",
+                },
+                {
+                    "ErrorEquals": ["ErrorC"],
+                    "Next": "TerminalState",
+                },
+            ],
+        },
+        "TerminalState": {"Type": "Fail"},
+    },
+}
+
+action_state_with_catchers_with_invalid_result_path = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {},
+            "ResultPath": "$.some_path",
+            "End": True,
+            "ExceptionOnActionFailure": True,
+            "Catch": [
+                {
+                    "ErrorEquals": ["ErrorA", "ErrorB"],
+                    "Next": "TerminalState",
+                    "ResultPath": "NOT_A_JSON_PATH",
+                }
+            ],
+        },
+        "TerminalState": {"Type": "Fail"},
+    },
+}
+
+action_state_with_catchers_with_empty_errors = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {},
+            "ResultPath": "$.some_path",
+            "End": True,
+            "ExceptionOnActionFailure": True,
+            "Catch": [
+                {
+                    "ErrorEquals": [],
+                    "Next": "TerminalState",
+                }
+            ],
+        },
+        "TerminalState": {"Type": "Fail"},
+    },
+}
+
+action_state_with_catchers_with_undefined_next = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {},
+            "ResultPath": "$.some_path",
+            "End": True,
+            "ExceptionOnActionFailure": True,
+            "Catch": [
+                {
+                    "ErrorEquals": ["ErrorA"],
+                    "Next": "TerminalState",
+                }
+            ],
+        },
+    },
+}
+
+action_state_with_exception_on_fail = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {},
+            "ResultPath": "$.some_path",
+            "End": True,
+            "ExceptionOnActionFailure": True,
+        },
+    },
+}
+
+
+action_state_with_non_boolean_exception_on_fail = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {},
+            "ResultPath": "$.some_path",
+            "End": True,
+            "ExceptionOnActionFailure": "True",
+        },
+    },
+}
+
+invalid_action_url = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "localhost:5000",
+            "Parameters": {},
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+postgresql_action_url = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "pgsql://localhost:5000",
+            "Parameters": {},
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+missing_parameters_and_input_path = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+
+input_path_is_not_json_path = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "InputPath": "NOT_JSON_PATH",
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+result_path_is_not_json_path = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "ResultPath": "NOT_JSON_PATH",
+            "End": True,
+        },
+    },
+}
+
+parameters_are_non_dict = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": True,
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+nested_parameters_with_json_path_syntax = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {"a_json_path.$": "$.a_json_path"},
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+nested_parameters_with_invalid_json_path_key = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {"not_a_json_path": "$.a_json_path"},
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+nested_parameters_with_invalid_json_path_value = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {"a_json_path.$": "not_a_json_path"},
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+missing_action_url = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "Parameters": True,
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+valid_flow_definitions = [
+    simple_action_state,
+    nested_parameters_with_json_path_syntax,
+    action_state_with_exception_on_fail,
+    action_state_with_catcher,
+    action_state_with_multiple_catchers,
+]
+invalid_flow_definitions = [
+    invalid_action_url,
+    postgresql_action_url,
+    missing_parameters_and_input_path,
+    result_path_is_not_json_path,
+    input_path_is_not_json_path,
+    parameters_are_non_dict,
+    nested_parameters_with_invalid_json_path_key,
+    nested_parameters_with_invalid_json_path_value,
+    missing_action_url,
+    action_state_with_non_boolean_exception_on_fail,
+    action_state_with_catchers_with_empty_errors,
+    action_state_with_catchers_with_undefined_next,
+    action_state_with_catchers_with_invalid_result_path,
+]
+
+
+@pytest.mark.parametrize("flow_def", valid_flow_definitions)
+def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
+    FlowDefinition(**flow_def)
+
+
+@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
+def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+    with pytest.raises(FlowValidationError) as ve:
+        FlowDefinition(**flow_def)
+
+    assert ve.type is FlowValidationError
+    # assert False, ve.value.errors()

--- a/tests/flow_validation/test_action_state.py
+++ b/tests/flow_validation/test_action_state.py
@@ -132,6 +132,28 @@ action_state_with_catchers_with_undefined_next = {
     },
 }
 
+action_state_with_catchers_with_extra_fields = {
+    "StartAt": "ActionState",
+    "States": {
+        "ActionState": {
+            "Type": "Action",
+            "Comment": "No info",
+            "ActionUrl": "http://localhost:5000",
+            "Parameters": {},
+            "ResultPath": "$.some_path",
+            "End": True,
+            "ExceptionOnActionFailure": True,
+            "Catch": [
+                {
+                    "ErrorEquals": ["ErrorA"],
+                    "Next": "TerminalState",
+                    "ThisIsAnExtraField": True,
+                }
+            ],
+        },
+    },
+}
+
 action_state_with_exception_on_fail = {
     "StartAt": "ActionState",
     "States": {
@@ -308,6 +330,7 @@ invalid_flow_definitions = [
     action_state_with_catchers_with_empty_errors,
     action_state_with_catchers_with_undefined_next,
     action_state_with_catchers_with_invalid_result_path,
+    action_state_with_catchers_with_extra_fields,
 ]
 
 

--- a/tests/flow_validation/test_action_state.py
+++ b/tests/flow_validation/test_action_state.py
@@ -260,19 +260,6 @@ nested_parameters_with_json_path_syntax = {
     },
 }
 
-nested_parameters_with_invalid_json_path_key = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {"not_a_json_path": "$.a_json_path"},
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
-}
 
 nested_parameters_with_invalid_json_path_value = {
     "StartAt": "ActionState",
@@ -315,7 +302,6 @@ invalid_flow_definitions = [
     result_path_is_not_json_path,
     input_path_is_not_json_path,
     parameters_are_non_dict,
-    nested_parameters_with_invalid_json_path_key,
     nested_parameters_with_invalid_json_path_value,
     missing_action_url,
     action_state_with_non_boolean_exception_on_fail,
@@ -327,7 +313,9 @@ invalid_flow_definitions = [
 
 @pytest.mark.parametrize("flow_def", valid_flow_definitions)
 def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    FlowDefinition(**flow_def)
+    flow_model = FlowDefinition(**flow_def)
+    flow_def_out = flow_model.dict(exclude_unset=True)
+    assert flow_def_out == flow_def
 
 
 @pytest.mark.parametrize("flow_def", invalid_flow_definitions)
@@ -336,4 +324,3 @@ def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
         FlowDefinition(**flow_def)
 
     assert ve.type is FlowValidationError
-    # assert False, ve.value.errors()

--- a/tests/flow_validation/test_action_state.py
+++ b/tests/flow_validation/test_action_state.py
@@ -2,322 +2,212 @@ import typing as t
 
 import pytest
 
-from globus_automate_client.models import FlowDefinition, FlowValidationError
-
-simple_action_state = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {},
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
-}
-
-action_state_with_catcher = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {},
-            "ResultPath": "$.some_path",
-            "End": True,
-            "ExceptionOnActionFailure": True,
-            "Catch": [
-                {
-                    "ErrorEquals": ["ErrorA", "ErrorB"],
-                    "Next": "TerminalState",
-                }
-            ],
-        },
-        "TerminalState": {"Type": "Fail"},
-    },
-}
-
-action_state_with_multiple_catchers = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {},
-            "ResultPath": "$.some_path",
-            "End": True,
-            "ExceptionOnActionFailure": True,
-            "Catch": [
-                {
-                    "ErrorEquals": ["ErrorA", "ErrorB"],
-                    "Next": "TerminalState",
-                },
-                {
-                    "ErrorEquals": ["ErrorC"],
-                    "Next": "TerminalState",
-                },
-            ],
-        },
-        "TerminalState": {"Type": "Fail"},
-    },
-}
+from globus_automate_client.models import ActionState, FlowValidationError
 
 action_state_with_catchers_with_invalid_result_path = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {},
-            "ResultPath": "$.some_path",
-            "End": True,
-            "ExceptionOnActionFailure": True,
-            "Catch": [
-                {
-                    "ErrorEquals": ["ErrorA", "ErrorB"],
-                    "Next": "TerminalState",
-                    "ResultPath": "NOT_A_JSON_PATH",
-                }
-            ],
-        },
-        "TerminalState": {"Type": "Fail"},
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "Parameters": {},
+    "ResultPath": "$.some_path",
+    "End": True,
+    "ExceptionOnActionFailure": True,
+    "Catch": [
+        {
+            "ErrorEquals": ["ErrorA", "ErrorB"],
+            "Next": "TerminalState",
+            "ResultPath": "NOT_A_JSON_PATH",
+        }
+    ],
 }
-
 action_state_with_catchers_with_empty_errors = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {},
-            "ResultPath": "$.some_path",
-            "End": True,
-            "ExceptionOnActionFailure": True,
-            "Catch": [
-                {
-                    "ErrorEquals": [],
-                    "Next": "TerminalState",
-                }
-            ],
-        },
-        "TerminalState": {"Type": "Fail"},
-    },
-}
-
-action_state_with_catchers_with_undefined_next = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {},
-            "ResultPath": "$.some_path",
-            "End": True,
-            "ExceptionOnActionFailure": True,
-            "Catch": [
-                {
-                    "ErrorEquals": ["ErrorA"],
-                    "Next": "TerminalState",
-                }
-            ],
-        },
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "Parameters": {},
+    "ResultPath": "$.some_path",
+    "End": True,
+    "ExceptionOnActionFailure": True,
+    "Catch": [
+        {
+            "ErrorEquals": [],
+            "Next": "TerminalState",
+        }
+    ],
 }
 
 action_state_with_catchers_with_extra_fields = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {},
-            "ResultPath": "$.some_path",
-            "End": True,
-            "ExceptionOnActionFailure": True,
-            "Catch": [
-                {
-                    "ErrorEquals": ["ErrorA"],
-                    "Next": "TerminalState",
-                    "ThisIsAnExtraField": True,
-                }
-            ],
-        },
-    },
-}
-
-action_state_with_exception_on_fail = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {},
-            "ResultPath": "$.some_path",
-            "End": True,
-            "ExceptionOnActionFailure": True,
-        },
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "Parameters": {},
+    "ResultPath": "$.some_path",
+    "End": True,
+    "ExceptionOnActionFailure": True,
+    "Catch": [
+        {
+            "ErrorEquals": ["ErrorA"],
+            "Next": "TerminalState",
+            "ThisIsAnExtraField": True,
+        }
+    ],
 }
 
 
 action_state_with_non_boolean_exception_on_fail = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {},
-            "ResultPath": "$.some_path",
-            "End": True,
-            "ExceptionOnActionFailure": "True",
-        },
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "Parameters": {},
+    "ResultPath": "$.some_path",
+    "End": True,
+    "ExceptionOnActionFailure": "True",
 }
 
 invalid_action_url = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "localhost:5000",
-            "Parameters": {},
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "localhost:5000",
+    "Parameters": {},
+    "ResultPath": "$.some_path",
+    "End": True,
 }
 
 postgresql_action_url = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "pgsql://localhost:5000",
-            "Parameters": {},
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "pgsql://localhost:5000",
+    "Parameters": {},
+    "ResultPath": "$.some_path",
+    "End": True,
 }
-
 missing_parameters_and_input_path = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "ResultPath": "$.some_path",
+    "End": True,
 }
 
 
 input_path_is_not_json_path = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "InputPath": "NOT_JSON_PATH",
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "InputPath": "NOT_JSON_PATH",
+    "ResultPath": "$.some_path",
+    "End": True,
 }
 
 result_path_is_not_json_path = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "ResultPath": "NOT_JSON_PATH",
-            "End": True,
-        },
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "ResultPath": "NOT_JSON_PATH",
+    "End": True,
 }
 
 parameters_are_non_dict = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": True,
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
-}
-
-nested_parameters_with_json_path_syntax = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {"a_json_path.$": "$.a_json_path"},
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "Parameters": True,
+    "ResultPath": "$.some_path",
+    "End": True,
 }
 
 
 nested_parameters_with_invalid_json_path_value = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "ActionUrl": "http://localhost:5000",
-            "Parameters": {"a_json_path.$": "not_a_json_path"},
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "Parameters": {"a_json_path.$": "not_a_json_path"},
+    "ResultPath": "$.some_path",
+    "End": True,
 }
 
 missing_action_url = {
-    "StartAt": "ActionState",
-    "States": {
-        "ActionState": {
-            "Type": "Action",
-            "Comment": "No info",
-            "Parameters": True,
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "Action",
+    "Comment": "No info",
+    "Parameters": True,
+    "ResultPath": "$.some_path",
+    "End": True,
 }
 
-valid_flow_definitions = [
+simple_action_state: t.Dict[str, t.Any] = {
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "Parameters": {},
+    "ResultPath": "$.some_path",
+    "End": True,
+}
+
+action_state_with_catcher: t.Dict[str, t.Any] = {
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "Parameters": {},
+    "ResultPath": "$.some_path",
+    "End": True,
+    "ExceptionOnActionFailure": True,
+    "Catch": [
+        {
+            "ErrorEquals": ["ErrorA", "ErrorB"],
+            "Next": "TerminalState",
+        }
+    ],
+}
+
+action_state_with_multiple_catchers: t.Dict[str, t.Any] = {
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "Parameters": {},
+    "ResultPath": "$.some_path",
+    "End": True,
+    "ExceptionOnActionFailure": True,
+    "Catch": [
+        {
+            "ErrorEquals": ["ErrorA", "ErrorB"],
+            "Next": "TerminalState",
+        },
+        {
+            "ErrorEquals": ["ErrorC"],
+            "Next": "TerminalState",
+        },
+    ],
+}
+
+nested_parameters_with_json_path_syntax: t.Dict[str, t.Any] = {
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "Parameters": {"a_json_path.$": "$.a_json_path"},
+    "ResultPath": "$.some_path",
+    "End": True,
+}
+
+action_state_with_exception_on_fail: t.Dict[str, t.Any] = {
+    "Type": "Action",
+    "Comment": "No info",
+    "ActionUrl": "http://localhost:5000",
+    "Parameters": {},
+    "ResultPath": "$.some_path",
+    "End": True,
+    "ExceptionOnActionFailure": True,
+}
+
+
+valid_state_definitions = [
+    action_state_with_catcher,
+    action_state_with_multiple_catchers,
     simple_action_state,
     nested_parameters_with_json_path_syntax,
     action_state_with_exception_on_fail,
-    action_state_with_catcher,
-    action_state_with_multiple_catchers,
 ]
-invalid_flow_definitions = [
+
+invalid_state_definitions = [
     invalid_action_url,
     postgresql_action_url,
     missing_parameters_and_input_path,
@@ -328,22 +218,21 @@ invalid_flow_definitions = [
     missing_action_url,
     action_state_with_non_boolean_exception_on_fail,
     action_state_with_catchers_with_empty_errors,
-    action_state_with_catchers_with_undefined_next,
     action_state_with_catchers_with_invalid_result_path,
     action_state_with_catchers_with_extra_fields,
 ]
 
 
-@pytest.mark.parametrize("flow_def", valid_flow_definitions)
-def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    flow_model = FlowDefinition(**flow_def)
-    flow_def_out = flow_model.dict(exclude_unset=True)
-    assert flow_def_out == flow_def
+@pytest.mark.parametrize("state_def", valid_state_definitions)
+def test_valid_action_states_pass_validation(state_def: t.Dict[str, t.Any]):
+    state_model = ActionState(**state_def)
+    state_def_out = state_model.dict(exclude_unset=True)
+    assert state_def_out == state_def
 
 
-@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
-def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+@pytest.mark.parametrize("state_def", invalid_state_definitions)
+def test_invalid_action_states_fail_validation(state_def: t.Dict[str, t.Any]):
     with pytest.raises(FlowValidationError) as ve:
-        FlowDefinition(**flow_def)
+        ActionState(**state_def)
 
     assert ve.type is FlowValidationError

--- a/tests/flow_validation/test_choice_state.py
+++ b/tests/flow_validation/test_choice_state.py
@@ -395,12 +395,166 @@ choice_state_with_invalid_comparison_operator = {
     },
 }
 
+choice_state_default_state_references_non_existant_state = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                    "Next": "ChoiceAState",
+                },
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                    "Next": "DefaultState",
+                },
+            ],
+            "Default": "THIS_TRANSITION_STATE_DOES_NOT_EXIST",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+choice_state_without_default = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                    "Next": "ChoiceAState",
+                },
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                    "Next": "DefaultState",
+                },
+            ],
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+
+choice_state_with_simple_nested_boolean_condition = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Not": {"Not": {"Variable": "$.key", "StringEquals": "value"}},
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+
+choice_state_with_conjunctive_nested_boolean_condition = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Not": {
+                        "Or": [
+                            {
+                                "Variable": "$.SomePath.status",
+                                "StringEquals": "FAILED",
+                            },
+                            {
+                                "Variable": "$.SomePath.status",
+                                "StringEquals": "FAILED",
+                            },
+                        ],
+                    },
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+
+choice_state_with_conjunctive_nested_boolean_condition_using_next = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Not": {
+                        "Or": [
+                            {
+                                "Variable": "$.SomePath.status",
+                                "StringEquals": "FAILED",
+                                "Next": "DefaultState",
+                            },
+                            {
+                                "Variable": "$.SomePath.status",
+                                "StringEquals": "FAILED",
+                            },
+                        ],
+                    },
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
 
 valid_flow_definitions = [
     simple_choice_state,
     choice_state_using_and,
     choice_state_using_or,
     choice_state_using_not,
+    choice_state_without_default,
+    choice_state_with_simple_nested_boolean_condition,
+    choice_state_with_conjunctive_nested_boolean_condition,
 ]
 invalid_flow_definitions = [
     invalid_next_in_choice,
@@ -412,12 +566,16 @@ invalid_flow_definitions = [
     choice_state_using_or_where_next_is_defined,
     choice_state_using_not_where_next_is_defined,
     choice_state_with_invalid_comparison_operator,
+    choice_state_default_state_references_non_existant_state,
+    choice_state_with_conjunctive_nested_boolean_condition_using_next,
 ]
 
 
 @pytest.mark.parametrize("flow_def", valid_flow_definitions)
 def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    FlowDefinition(**flow_def)
+    flow_model = FlowDefinition(**flow_def)
+    flow_def_out = flow_model.dict(exclude_unset=True)
+    assert flow_def_out == flow_def
 
 
 @pytest.mark.parametrize("flow_def", invalid_flow_definitions)

--- a/tests/flow_validation/test_choice_state.py
+++ b/tests/flow_validation/test_choice_state.py
@@ -315,6 +315,35 @@ choice_state_with_conjunctive_nested_boolean_condition_with_extra_fields = {
     "Default": "DefaultState",
 }
 
+choice_state_with_non_boolean_data_test_expression = {
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Not": {
+                "Variable": "$.SomePath.status",
+                "IsString": "True",  # this must be a boolean
+            },
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
+}
+
+choice_state_with_boolean_data_test_expression = {
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Not": {
+                "Variable": "$.SomePath.status",
+                "IsString": True,
+            },
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
+}
 
 valid_state_definitions = [
     simple_choice_state,
@@ -324,6 +353,7 @@ valid_state_definitions = [
     choice_state_without_default,
     choice_state_with_simple_nested_boolean_condition,
     choice_state_with_conjunctive_nested_boolean_condition,
+    choice_state_with_boolean_data_test_expression,
 ]
 invalid_state_definitions = [
     choice_state_using_empty_or,
@@ -335,6 +365,7 @@ invalid_state_definitions = [
     choice_state_with_invalid_comparison_operator,
     choice_state_with_conjunctive_nested_boolean_condition_using_next,
     choice_state_with_conjunctive_nested_boolean_condition_with_extra_fields,
+    choice_state_with_non_boolean_data_test_expression,
 ]
 
 

--- a/tests/flow_validation/test_choice_state.py
+++ b/tests/flow_validation/test_choice_state.py
@@ -2,587 +2,321 @@ import typing as t
 
 import pytest
 
-from globus_automate_client.models import FlowDefinition, FlowValidationError
+from globus_automate_client.models import ChoiceState, FlowValidationError
 
 simple_choice_state = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Variable": "$.SomePath.status",
-                    "StringEquals": "FAILED",
-                    "Next": "ChoiceAState",
-                },
-                {
-                    "Variable": "$.SomePath.status",
-                    "StringEquals": "FAILED",
-                    "Next": "DefaultState",
-                },
-            ],
-            "Default": "DefaultState",
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Variable": "$.SomePath.status",
+            "StringEquals": "FAILED",
+            "Next": "ChoiceAState",
         },
-        "DefaultState": {
-            "Type": "Fail",
+        {
+            "Variable": "$.SomePath.status",
+            "StringEquals": "FAILED",
+            "Next": "DefaultState",
         },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
-}
-
-invalid_next_in_choice = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Variable": "$.SomePath.status",
-                    "StringEquals": "FAILED",
-                    "Next": "NOT_A_STATE",
-                }
-            ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
-}
-
-invalid_default_for_choice = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Variable": "$.SomePath.status",
-                    "StringEquals": "FAILED",
-                    "Next": "ChoiceAState",
-                }
-            ],
-            "Default": "NotAState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+    ],
+    "Default": "DefaultState",
 }
 
 
 choice_state_using_and = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "And": [
                 {
-                    "And": [
-                        {
-                            "Variable": "$.SomePath.status",
-                            "StringEquals": "FAILED",
-                        },
-                        {
-                            "Variable": "$.SomePath.status",
-                            "StringEquals": "FAILED",
-                        },
-                    ],
-                    "Next": "ChoiceAState",
-                }
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                },
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                },
             ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
 }
 
 choice_state_using_or = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Or": [
                 {
-                    "Or": [
-                        {
-                            "Variable": "$.SomePath.status",
-                            "StringEquals": "FAILED",
-                        },
-                        {
-                            "Variable": "$.SomePath.status",
-                            "StringEquals": "FAILED",
-                        },
-                    ],
-                    "Next": "ChoiceAState",
-                }
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                },
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                },
             ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
 }
 
 choice_state_using_not = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Not": {
-                        "Variable": "$.SomePath.status",
-                        "StringEquals": "FAILED",
-                    },
-                    "Next": "ChoiceAState",
-                }
-            ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Not": {
+                "Variable": "$.SomePath.status",
+                "StringEquals": "FAILED",
+            },
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
 }
 
 choice_state_using_empty_or = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Or": [],
-                    "Next": "ChoiceAState",
-                }
-            ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Or": [],
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
 }
 
 choice_state_using_empty_and = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "And": [],
-                    "Next": "ChoiceAState",
-                }
-            ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "And": [],
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
 }
 
 choice_state_using_and_and_or = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Or": [
                 {
-                    "Or": [
-                        {
-                            "Variable": "$.SomePath.status",
-                            "StringEquals": "FAILED",
-                        },
-                        {
-                            "Variable": "$.SomePath.status",
-                            "StringEquals": "FAILED",
-                        },
-                    ],
-                    "Next": "ChoiceAState",
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
                 },
                 {
-                    "And": [
-                        {
-                            "Variable": "$.SomePath.status",
-                            "StringEquals": "FAILED",
-                        },
-                        {
-                            "Variable": "$.SomePath.status",
-                            "StringEquals": "FAILED",
-                        },
-                    ],
-                    "Next": "ChoiceAState",
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
                 },
             ],
-            "Default": "DefaultState",
+            "Next": "ChoiceAState",
         },
-        "DefaultState": {
-            "Type": "Fail",
+        {
+            "And": [
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                },
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                },
+            ],
+            "Next": "ChoiceAState",
         },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+    ],
+    "Default": "DefaultState",
 }
 
 empty_choices_for_choice_state = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [],
+    "Default": "DefaultState",
 }
 
 extra_fields_set_on_choice_state = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "ThisIsAnExtraField": True,
-            "Choices": [
-                {
-                    "Variable": "$.SomePath.status",
-                    "StringEquals": "FAILED",
-                    "Next": "ChoiceAState",
-                },
-                {
-                    "Variable": "$.SomePath.status",
-                    "StringEquals": "FAILED",
-                    "Next": "DefaultState",
-                },
-            ],
-            "Default": "DefaultState",
+    "Type": "Choice",
+    "Comment": "No info",
+    "ThisIsAnExtraField": True,
+    "Choices": [
+        {
+            "Variable": "$.SomePath.status",
+            "StringEquals": "FAILED",
+            "Next": "ChoiceAState",
         },
-        "DefaultState": {
-            "Type": "Fail",
+        {
+            "Variable": "$.SomePath.status",
+            "StringEquals": "FAILED",
+            "Next": "DefaultState",
         },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+    ],
+    "Default": "DefaultState",
 }
 
 choice_state_using_or_where_next_is_defined = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Or": [
                 {
-                    "Or": [
-                        {
-                            "Variable": "$.SomePath.status",
-                            "StringEquals": "FAILED",
-                            "Next": "ChoiceAState",
-                        },
-                        {
-                            "Variable": "$.SomePath.status",
-                            "StringEquals": "FAILED",
-                        },
-                    ],
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
                     "Next": "ChoiceAState",
-                }
+                },
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                },
             ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
 }
 
 choice_state_using_not_where_next_is_defined = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Not": {
-                        "Variable": "$.SomePath.status",
-                        "StringEquals": "FAILED",
-                        "Next": "ChoiceAState",
-                    },
-                    "Next": "ChoiceAState",
-                }
-            ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Not": {
+                "Variable": "$.SomePath.status",
+                "StringEquals": "FAILED",
+                "Next": "ChoiceAState",
+            },
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
 }
 
 choice_state_with_invalid_comparison_operator = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Variable": "$.SomePath.status",
-                    "NOT_AN_OPERATOR": "FAILED",
-                    "Next": "ChoiceAState",
-                },
-            ],
-            "Default": "DefaultState",
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Variable": "$.SomePath.status",
+            "NOT_AN_OPERATOR": "FAILED",
+            "Next": "ChoiceAState",
         },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
-}
-
-choice_state_default_state_references_non_existant_state = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Variable": "$.SomePath.status",
-                    "StringEquals": "FAILED",
-                    "Next": "ChoiceAState",
-                },
-                {
-                    "Variable": "$.SomePath.status",
-                    "StringEquals": "FAILED",
-                    "Next": "DefaultState",
-                },
-            ],
-            "Default": "THIS_TRANSITION_STATE_DOES_NOT_EXIST",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+    ],
+    "Default": "DefaultState",
 }
 
 choice_state_without_default = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Variable": "$.SomePath.status",
-                    "StringEquals": "FAILED",
-                    "Next": "ChoiceAState",
-                },
-                {
-                    "Variable": "$.SomePath.status",
-                    "StringEquals": "FAILED",
-                    "Next": "DefaultState",
-                },
-            ],
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Variable": "$.SomePath.status",
+            "StringEquals": "FAILED",
+            "Next": "ChoiceAState",
         },
-        "DefaultState": {
-            "Type": "Fail",
+        {
+            "Variable": "$.SomePath.status",
+            "StringEquals": "FAILED",
+            "Next": "DefaultState",
         },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+    ],
 }
-
 
 choice_state_with_simple_nested_boolean_condition = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Not": {"Not": {"Variable": "$.key", "StringEquals": "value"}},
-                    "Next": "ChoiceAState",
-                }
-            ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Not": {"Not": {"Variable": "$.key", "StringEquals": "value"}},
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
 }
-
 
 choice_state_with_conjunctive_nested_boolean_condition = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Not": {
-                        "Or": [
-                            {
-                                "Variable": "$.SomePath.status",
-                                "StringEquals": "FAILED",
-                            },
-                            {
-                                "Variable": "$.SomePath.status",
-                                "StringEquals": "FAILED",
-                            },
-                        ],
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Not": {
+                "Or": [
+                    {
+                        "Variable": "$.SomePath.status",
+                        "StringEquals": "FAILED",
                     },
-                    "Next": "ChoiceAState",
-                }
-            ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+                    {
+                        "Variable": "$.SomePath.status",
+                        "StringEquals": "FAILED",
+                    },
+                ],
+            },
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
 }
 
-
 choice_state_with_conjunctive_nested_boolean_condition_using_next = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Not": {
-                        "Or": [
-                            {
-                                "Variable": "$.SomePath.status",
-                                "StringEquals": "FAILED",
-                                "Next": "DefaultState",
-                            },
-                            {
-                                "Variable": "$.SomePath.status",
-                                "StringEquals": "FAILED",
-                            },
-                        ],
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Not": {
+                "Or": [
+                    {
+                        "Variable": "$.SomePath.status",
+                        "StringEquals": "FAILED",
+                        "Next": "DefaultState",
                     },
-                    "Next": "ChoiceAState",
-                }
-            ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+                    {
+                        "Variable": "$.SomePath.status",
+                        "StringEquals": "FAILED",
+                    },
+                ],
+            },
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
 }
 
 choice_state_with_conjunctive_nested_boolean_condition_with_extra_fields = {
-    "StartAt": "ChoiceState",
-    "States": {
-        "ChoiceState": {
-            "Type": "Choice",
-            "Comment": "No info",
-            "Choices": [
-                {
-                    "Not": {
-                        "Or": [
-                            {
-                                "Variable": "$.SomePath.status",
-                                "StringEquals": "FAILED",
-                                "ThisIsAnExtraField": True,
-                            },
-                            {
-                                "Variable": "$.SomePath.status",
-                                "StringEquals": "FAILED",
-                            },
-                        ],
+    "Type": "Choice",
+    "Comment": "No info",
+    "Choices": [
+        {
+            "Not": {
+                "Or": [
+                    {
+                        "Variable": "$.SomePath.status",
+                        "StringEquals": "FAILED",
+                        "ThisIsAnExtraField": True,
                     },
-                    "Next": "ChoiceAState",
-                }
-            ],
-            "Default": "DefaultState",
-        },
-        "DefaultState": {
-            "Type": "Fail",
-        },
-        "ChoiceAState": {
-            "Type": "Fail",
-        },
-    },
+                    {
+                        "Variable": "$.SomePath.status",
+                        "StringEquals": "FAILED",
+                    },
+                ],
+            },
+            "Next": "ChoiceAState",
+        }
+    ],
+    "Default": "DefaultState",
 }
 
-valid_flow_definitions = [
+
+valid_state_definitions = [
     simple_choice_state,
     choice_state_using_and,
     choice_state_using_or,
@@ -591,9 +325,7 @@ valid_flow_definitions = [
     choice_state_with_simple_nested_boolean_condition,
     choice_state_with_conjunctive_nested_boolean_condition,
 ]
-invalid_flow_definitions = [
-    invalid_next_in_choice,
-    invalid_default_for_choice,
+invalid_state_definitions = [
     choice_state_using_empty_or,
     choice_state_using_empty_and,
     empty_choices_for_choice_state,
@@ -601,23 +333,21 @@ invalid_flow_definitions = [
     choice_state_using_or_where_next_is_defined,
     choice_state_using_not_where_next_is_defined,
     choice_state_with_invalid_comparison_operator,
-    choice_state_default_state_references_non_existant_state,
     choice_state_with_conjunctive_nested_boolean_condition_using_next,
     choice_state_with_conjunctive_nested_boolean_condition_with_extra_fields,
 ]
 
 
-@pytest.mark.parametrize("flow_def", valid_flow_definitions)
-def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    flow_model = FlowDefinition(**flow_def)
-    flow_def_out = flow_model.dict(exclude_unset=True)
-    assert flow_def_out == flow_def
+@pytest.mark.parametrize("state_def", valid_state_definitions)
+def test_valid_choice_states_pass_validation(state_def: t.Dict[str, t.Any]):
+    state_model = ChoiceState(**state_def)
+    state_def_out = state_model.dict(exclude_unset=True)
+    assert state_def_out == state_def
 
 
-@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
-def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+@pytest.mark.parametrize("state_def", invalid_state_definitions)
+def test_invalid_choice_states_fail_validation(state_def: t.Dict[str, t.Any]):
     with pytest.raises(FlowValidationError) as ve:
-        FlowDefinition(**flow_def)
+        ChoiceState(**state_def)
 
     assert ve.type is FlowValidationError
-    # assert False, ve.value.errors()

--- a/tests/flow_validation/test_choice_state.py
+++ b/tests/flow_validation/test_choice_state.py
@@ -1,0 +1,429 @@
+import typing as t
+
+import pytest
+
+from globus_automate_client.models import FlowDefinition, FlowValidationError
+
+simple_choice_state = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                    "Next": "ChoiceAState",
+                },
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                    "Next": "DefaultState",
+                },
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+invalid_next_in_choice = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                    "Next": "NOT_A_STATE",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+invalid_default_for_choice = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "NotAState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+
+choice_state_using_and = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "And": [
+                        {
+                            "Variable": "$.SomePath.status",
+                            "StringEquals": "FAILED",
+                        },
+                        {
+                            "Variable": "$.SomePath.status",
+                            "StringEquals": "FAILED",
+                        },
+                    ],
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+choice_state_using_or = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Or": [
+                        {
+                            "Variable": "$.SomePath.status",
+                            "StringEquals": "FAILED",
+                        },
+                        {
+                            "Variable": "$.SomePath.status",
+                            "StringEquals": "FAILED",
+                        },
+                    ],
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+choice_state_using_not = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Not": {
+                        "Variable": "$.SomePath.status",
+                        "StringEquals": "FAILED",
+                    },
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+choice_state_using_empty_or = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Or": [],
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+choice_state_using_empty_and = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "And": [],
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+choice_state_using_and_and_or = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Or": [
+                        {
+                            "Variable": "$.SomePath.status",
+                            "StringEquals": "FAILED",
+                        },
+                        {
+                            "Variable": "$.SomePath.status",
+                            "StringEquals": "FAILED",
+                        },
+                    ],
+                    "Next": "ChoiceAState",
+                },
+                {
+                    "And": [
+                        {
+                            "Variable": "$.SomePath.status",
+                            "StringEquals": "FAILED",
+                        },
+                        {
+                            "Variable": "$.SomePath.status",
+                            "StringEquals": "FAILED",
+                        },
+                    ],
+                    "Next": "ChoiceAState",
+                },
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+empty_choices_for_choice_state = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+extra_fields_set_on_choice_state = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "ThisIsAnExtraField": True,
+            "Choices": [
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                    "Next": "ChoiceAState",
+                },
+                {
+                    "Variable": "$.SomePath.status",
+                    "StringEquals": "FAILED",
+                    "Next": "DefaultState",
+                },
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+choice_state_using_or_where_next_is_defined = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Or": [
+                        {
+                            "Variable": "$.SomePath.status",
+                            "StringEquals": "FAILED",
+                            "Next": "ChoiceAState",
+                        },
+                        {
+                            "Variable": "$.SomePath.status",
+                            "StringEquals": "FAILED",
+                        },
+                    ],
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+choice_state_using_not_where_next_is_defined = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Not": {
+                        "Variable": "$.SomePath.status",
+                        "StringEquals": "FAILED",
+                        "Next": "ChoiceAState",
+                    },
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+choice_state_with_invalid_comparison_operator = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Variable": "$.SomePath.status",
+                    "NOT_AN_OPERATOR": "FAILED",
+                    "Next": "ChoiceAState",
+                },
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
+
+valid_flow_definitions = [
+    simple_choice_state,
+    choice_state_using_and,
+    choice_state_using_or,
+    choice_state_using_not,
+]
+invalid_flow_definitions = [
+    invalid_next_in_choice,
+    invalid_default_for_choice,
+    choice_state_using_empty_or,
+    choice_state_using_empty_and,
+    empty_choices_for_choice_state,
+    extra_fields_set_on_choice_state,
+    choice_state_using_or_where_next_is_defined,
+    choice_state_using_not_where_next_is_defined,
+    choice_state_with_invalid_comparison_operator,
+]
+
+
+@pytest.mark.parametrize("flow_def", valid_flow_definitions)
+def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
+    FlowDefinition(**flow_def)
+
+
+@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
+def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+    with pytest.raises(FlowValidationError) as ve:
+        FlowDefinition(**flow_def)
+
+    assert ve.type is FlowValidationError
+    # assert False, ve.value.errors()

--- a/tests/flow_validation/test_choice_state.py
+++ b/tests/flow_validation/test_choice_state.py
@@ -547,6 +547,41 @@ choice_state_with_conjunctive_nested_boolean_condition_using_next = {
     },
 }
 
+choice_state_with_conjunctive_nested_boolean_condition_with_extra_fields = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Comment": "No info",
+            "Choices": [
+                {
+                    "Not": {
+                        "Or": [
+                            {
+                                "Variable": "$.SomePath.status",
+                                "StringEquals": "FAILED",
+                                "ThisIsAnExtraField": True,
+                            },
+                            {
+                                "Variable": "$.SomePath.status",
+                                "StringEquals": "FAILED",
+                            },
+                        ],
+                    },
+                    "Next": "ChoiceAState",
+                }
+            ],
+            "Default": "DefaultState",
+        },
+        "DefaultState": {
+            "Type": "Fail",
+        },
+        "ChoiceAState": {
+            "Type": "Fail",
+        },
+    },
+}
+
 valid_flow_definitions = [
     simple_choice_state,
     choice_state_using_and,
@@ -568,6 +603,7 @@ invalid_flow_definitions = [
     choice_state_with_invalid_comparison_operator,
     choice_state_default_state_references_non_existant_state,
     choice_state_with_conjunctive_nested_boolean_condition_using_next,
+    choice_state_with_conjunctive_nested_boolean_condition_with_extra_fields,
 ]
 
 

--- a/tests/flow_validation/test_example_flows.py
+++ b/tests/flow_validation/test_example_flows.py
@@ -1,6 +1,5 @@
 import glob
 import os
-import typing as t
 
 import pytest
 import yaml

--- a/tests/flow_validation/test_example_flows.py
+++ b/tests/flow_validation/test_example_flows.py
@@ -10,5 +10,7 @@ from globus_automate_client.models import FlowDefinition
 @pytest.mark.parametrize("filename", glob.glob("./examples/flows/*/definition*"))
 def test_example_flow(filename: str):
     with open(os.path.join(os.getcwd(), filename), "r") as f:
-        flow_def = yaml.safe_load(f)
-        FlowDefinition(**flow_def).json(indent=2)
+        flow_def_in = yaml.safe_load(f)
+        flow_model = FlowDefinition(**flow_def_in)
+        flow_def_out = flow_model.dict(exclude_unset=True)
+        assert flow_def_out == flow_def_in

--- a/tests/flow_validation/test_example_flows.py
+++ b/tests/flow_validation/test_example_flows.py
@@ -1,0 +1,15 @@
+import glob
+import os
+import typing as t
+
+import pytest
+import yaml
+
+from globus_automate_client.models import FlowDefinition
+
+
+@pytest.mark.parametrize("filename", glob.glob("./examples/flows/*/definition*"))
+def test_example_flow(filename: str):
+    with open(os.path.join(os.getcwd(), filename), "r") as f:
+        flow_def = yaml.safe_load(f)
+        FlowDefinition(**flow_def).json(indent=2)

--- a/tests/flow_validation/test_expression_eval_state.py
+++ b/tests/flow_validation/test_expression_eval_state.py
@@ -1,0 +1,133 @@
+import typing as t
+
+import pytest
+
+from globus_automate_client.models import FlowDefinition, FlowValidationError
+
+simple_eval_state = {
+    "StartAt": "ExpressionEval",
+    "States": {
+        "ExpressionEval": {
+            "Type": "ExpressionEval",
+            "Comment": "No info",
+            "Parameters": None,
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+nested_parameters_with_json_path_syntax = {
+    "StartAt": "ExpressionEval",
+    "States": {
+        "ExpressionEval": {
+            "Type": "ExpressionEval",
+            "Comment": "No info",
+            "Parameters": {"nested_json_path.$": "$.some_path"},
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+nested_parameters_with_invalid_json_path_key = {
+    "StartAt": "ExpressionEval",
+    "States": {
+        "ExpressionEval": {
+            "Type": "ExpressionEval",
+            "Comment": "No info",
+            "Parameters": {"invalid_json_path_indicator": "$.some_path"},
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+nested_parameters_with_invalid_json_path_value = {
+    "StartAt": "ExpressionEval",
+    "States": {
+        "ExpressionEval": {
+            "Type": "ExpressionEval",
+            "Comment": "No info",
+            "Parameters": {"invalid_json_path_indicator.$": "$$$$some_path"},
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+missing_next_and_end = {
+    "StartAt": "ExpressionEval",
+    "States": {
+        "ExpressionEval": {
+            "Type": "ExpressionEval",
+            "Comment": "No info",
+            "Parameters": None,
+            "ResultPath": "$.some_path",
+        },
+    },
+}
+
+result_path_is_non_jsonpath = {
+    "StartAt": "ExpressionEval",
+    "States": {
+        "ExpressionEval": {
+            "Type": "ExpressionEval",
+            "Comment": "No info",
+            "Parameters": None,
+            "ResultPath": "NOT_JSON_PATH",
+            "End": True,
+        },
+    },
+}
+
+parameters_are_non_dict = {
+    "StartAt": "ExpressionEval",
+    "States": {
+        "ExpressionEval": {
+            "Type": "ExpressionEval",
+            "Comment": "No info",
+            "Parameters": "None",
+            "ResultPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+extra_fields_set = {
+    "StartAt": "ExpressionEval",
+    "States": {
+        "ExpressionEval": {
+            "Type": "ExpressionEval",
+            "Comment": "No info",
+            "Parameters": None,
+            "ResultPath": "$.some_path",
+            "End": True,
+            "Endd": True,
+        },
+    },
+}
+
+
+valid_flow_definitions = [simple_eval_state, nested_parameters_with_json_path_syntax]
+invalid_flow_definitions = [
+    missing_next_and_end,
+    result_path_is_non_jsonpath,
+    parameters_are_non_dict,
+    extra_fields_set,
+    nested_parameters_with_invalid_json_path_key,
+    nested_parameters_with_invalid_json_path_value,
+]
+
+
+@pytest.mark.parametrize("flow_def", valid_flow_definitions)
+def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
+    FlowDefinition(**flow_def)
+
+
+@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
+def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+    with pytest.raises(FlowValidationError) as ve:
+        FlowDefinition(**flow_def)
+
+    assert ve.type is FlowValidationError

--- a/tests/flow_validation/test_expression_eval_state.py
+++ b/tests/flow_validation/test_expression_eval_state.py
@@ -2,103 +2,67 @@ import typing as t
 
 import pytest
 
-from globus_automate_client.models import FlowDefinition, FlowValidationError
+from globus_automate_client.models import ExpressionEvalState, FlowValidationError
 
 simple_eval_state = {
-    "StartAt": "ExpressionEval",
-    "States": {
-        "ExpressionEval": {
-            "Type": "ExpressionEval",
-            "Comment": "No info",
-            "Parameters": None,
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "ExpressionEval",
+    "Comment": "No info",
+    "Parameters": None,
+    "ResultPath": "$.some_path",
+    "End": True,
 }
 
 nested_parameters_with_json_path_syntax = {
-    "StartAt": "ExpressionEval",
-    "States": {
-        "ExpressionEval": {
-            "Type": "ExpressionEval",
-            "Comment": "No info",
-            "Parameters": {"nested_json_path.$": "$.some_path"},
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "ExpressionEval",
+    "Comment": "No info",
+    "Parameters": {"nested_json_path.$": "$.some_path"},
+    "ResultPath": "$.some_path",
+    "End": True,
 }
 
 
 nested_parameters_with_invalid_json_path_value = {
-    "StartAt": "ExpressionEval",
-    "States": {
-        "ExpressionEval": {
-            "Type": "ExpressionEval",
-            "Comment": "No info",
-            "Parameters": {"invalid_json_path_indicator.$": "$$$$some_path"},
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "ExpressionEval",
+    "Comment": "No info",
+    "Parameters": {"invalid_json_path_indicator.$": "$$$$some_path"},
+    "ResultPath": "$.some_path",
+    "End": True,
 }
 
 missing_next_and_end = {
-    "StartAt": "ExpressionEval",
-    "States": {
-        "ExpressionEval": {
-            "Type": "ExpressionEval",
-            "Comment": "No info",
-            "Parameters": None,
-            "ResultPath": "$.some_path",
-        },
-    },
+    "Type": "ExpressionEval",
+    "Comment": "No info",
+    "Parameters": None,
+    "ResultPath": "$.some_path",
 }
 
 result_path_is_non_jsonpath = {
-    "StartAt": "ExpressionEval",
-    "States": {
-        "ExpressionEval": {
-            "Type": "ExpressionEval",
-            "Comment": "No info",
-            "Parameters": None,
-            "ResultPath": "NOT_JSON_PATH",
-            "End": True,
-        },
-    },
+    "Type": "ExpressionEval",
+    "Comment": "No info",
+    "Parameters": None,
+    "ResultPath": "NOT_JSON_PATH",
+    "End": True,
 }
 
 parameters_are_non_dict = {
-    "StartAt": "ExpressionEval",
-    "States": {
-        "ExpressionEval": {
-            "Type": "ExpressionEval",
-            "Comment": "No info",
-            "Parameters": "None",
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "ExpressionEval",
+    "Comment": "No info",
+    "Parameters": "None",
+    "ResultPath": "$.some_path",
+    "End": True,
 }
 
 extra_fields_set = {
-    "StartAt": "ExpressionEval",
-    "States": {
-        "ExpressionEval": {
-            "Type": "ExpressionEval",
-            "Comment": "No info",
-            "Parameters": None,
-            "ResultPath": "$.some_path",
-            "End": True,
-            "Endd": True,
-        },
-    },
+    "Type": "ExpressionEval",
+    "Comment": "No info",
+    "Parameters": None,
+    "ResultPath": "$.some_path",
+    "End": True,
+    "Endd": True,
 }
 
-
-valid_flow_definitions = [simple_eval_state, nested_parameters_with_json_path_syntax]
-invalid_flow_definitions = [
+valid_state_definitions = [simple_eval_state, nested_parameters_with_json_path_syntax]
+invalid_state_definitions = [
     missing_next_and_end,
     result_path_is_non_jsonpath,
     parameters_are_non_dict,
@@ -107,16 +71,16 @@ invalid_flow_definitions = [
 ]
 
 
-@pytest.mark.parametrize("flow_def", valid_flow_definitions)
-def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    flow_model = FlowDefinition(**flow_def)
-    flow_def_out = flow_model.dict(exclude_unset=True)
-    assert flow_def_out == flow_def
+@pytest.mark.parametrize("state_def", valid_state_definitions)
+def test_valid_expression_eval_states_pass_validation(state_def: t.Dict[str, t.Any]):
+    state_model = ExpressionEvalState(**state_def)
+    state_def_out = state_model.dict(exclude_unset=True)
+    assert state_def_out == state_def
 
 
-@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
-def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+@pytest.mark.parametrize("state_def", invalid_state_definitions)
+def test_invalid_expression_eval_states_fail_validation(state_def: t.Dict[str, t.Any]):
     with pytest.raises(FlowValidationError) as ve:
-        FlowDefinition(**flow_def)
+        ExpressionEvalState(**state_def)
 
     assert ve.type is FlowValidationError

--- a/tests/flow_validation/test_expression_eval_state.py
+++ b/tests/flow_validation/test_expression_eval_state.py
@@ -30,18 +30,6 @@ nested_parameters_with_json_path_syntax = {
     },
 }
 
-nested_parameters_with_invalid_json_path_key = {
-    "StartAt": "ExpressionEval",
-    "States": {
-        "ExpressionEval": {
-            "Type": "ExpressionEval",
-            "Comment": "No info",
-            "Parameters": {"invalid_json_path_indicator": "$.some_path"},
-            "ResultPath": "$.some_path",
-            "End": True,
-        },
-    },
-}
 
 nested_parameters_with_invalid_json_path_value = {
     "StartAt": "ExpressionEval",
@@ -115,14 +103,15 @@ invalid_flow_definitions = [
     result_path_is_non_jsonpath,
     parameters_are_non_dict,
     extra_fields_set,
-    nested_parameters_with_invalid_json_path_key,
     nested_parameters_with_invalid_json_path_value,
 ]
 
 
 @pytest.mark.parametrize("flow_def", valid_flow_definitions)
 def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    FlowDefinition(**flow_def)
+    flow_model = FlowDefinition(**flow_def)
+    flow_def_out = flow_model.dict(exclude_unset=True)
+    assert flow_def_out == flow_def
 
 
 @pytest.mark.parametrize("flow_def", invalid_flow_definitions)

--- a/tests/flow_validation/test_fail_state.py
+++ b/tests/flow_validation/test_fail_state.py
@@ -1,0 +1,69 @@
+import typing as t
+
+import pytest
+
+from globus_automate_client.models import FlowDefinition, FlowValidationError
+
+simple_fail_state = {
+    "StartAt": "InstantFail",
+    "States": {
+        "InstantFail": {
+            "Type": "Fail",
+            "Comment": "No info",
+        },
+    },
+}
+
+detailed_fail_state = {
+    "StartAt": "InstantFail",
+    "States": {
+        "InstantFail": {
+            "Type": "Fail",
+            "Comment": "No info",
+            "Cause": "SomeCause",
+            "Error": "SomeError",
+        },
+    },
+}
+
+extra_fields_fail_state = {
+    "StartAt": "InstantFail",
+    "States": {
+        "InstantFail": {
+            "Type": "Fail",
+            "Comment": "No info",
+            "Cause": "SomeCause",
+            "Error": "SomeError",
+            "SomeExtraField": "SomeValue",
+        },
+    },
+}
+
+next_state_not_allowed = {
+    "StartAt": "InstantFail",
+    "States": {
+        "InstantFail": {
+            "Type": "Fail",
+            "Comment": "No info",
+            "Next": "SomeState",
+        },
+        "SomeState": {"Type": "Pass", "End": True},
+    },
+}
+
+
+valid_flow_definitions = [simple_fail_state, detailed_fail_state]
+invalid_flow_definitions = [extra_fields_fail_state, next_state_not_allowed]
+
+
+@pytest.mark.parametrize("flow_def", valid_flow_definitions)
+def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
+    FlowDefinition(**flow_def)
+
+
+@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
+def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+    with pytest.raises(FlowValidationError) as ve:
+        FlowDefinition(**flow_def)
+
+    assert ve.type is FlowValidationError

--- a/tests/flow_validation/test_fail_state.py
+++ b/tests/flow_validation/test_fail_state.py
@@ -58,7 +58,9 @@ invalid_flow_definitions = [extra_fields_fail_state, next_state_not_allowed]
 
 @pytest.mark.parametrize("flow_def", valid_flow_definitions)
 def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    FlowDefinition(**flow_def)
+    flow_model = FlowDefinition(**flow_def)
+    flow_def_out = flow_model.dict(exclude_unset=True)
+    assert flow_def_out == flow_def
 
 
 @pytest.mark.parametrize("flow_def", invalid_flow_definitions)

--- a/tests/flow_validation/test_fail_state.py
+++ b/tests/flow_validation/test_fail_state.py
@@ -2,70 +2,49 @@ import typing as t
 
 import pytest
 
-from globus_automate_client.models import FlowDefinition, FlowValidationError
+from globus_automate_client.models import FailState, FlowValidationError
 
 simple_fail_state = {
-    "StartAt": "InstantFail",
-    "States": {
-        "InstantFail": {
-            "Type": "Fail",
-            "Comment": "No info",
-        },
-    },
+    "Type": "Fail",
+    "Comment": "No info",
 }
 
 detailed_fail_state = {
-    "StartAt": "InstantFail",
-    "States": {
-        "InstantFail": {
-            "Type": "Fail",
-            "Comment": "No info",
-            "Cause": "SomeCause",
-            "Error": "SomeError",
-        },
-    },
+    "Type": "Fail",
+    "Comment": "No info",
+    "Cause": "SomeCause",
+    "Error": "SomeError",
 }
 
 extra_fields_fail_state = {
-    "StartAt": "InstantFail",
-    "States": {
-        "InstantFail": {
-            "Type": "Fail",
-            "Comment": "No info",
-            "Cause": "SomeCause",
-            "Error": "SomeError",
-            "SomeExtraField": "SomeValue",
-        },
-    },
+    "Type": "Fail",
+    "Comment": "No info",
+    "Cause": "SomeCause",
+    "Error": "SomeError",
+    "SomeExtraField": "SomeValue",
 }
 
 next_state_not_allowed = {
-    "StartAt": "InstantFail",
-    "States": {
-        "InstantFail": {
-            "Type": "Fail",
-            "Comment": "No info",
-            "Next": "SomeState",
-        },
-        "SomeState": {"Type": "Pass", "End": True},
-    },
+    "Type": "Fail",
+    "Comment": "No info",
+    "Next": "SomeState",
 }
 
 
-valid_flow_definitions = [simple_fail_state, detailed_fail_state]
-invalid_flow_definitions = [extra_fields_fail_state, next_state_not_allowed]
+valid_state_definitions = [simple_fail_state, detailed_fail_state]
+invalid_state_definitions = [extra_fields_fail_state, next_state_not_allowed]
 
 
-@pytest.mark.parametrize("flow_def", valid_flow_definitions)
-def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    flow_model = FlowDefinition(**flow_def)
-    flow_def_out = flow_model.dict(exclude_unset=True)
-    assert flow_def_out == flow_def
+@pytest.mark.parametrize("state_def", valid_state_definitions)
+def test_valid_fail_states_pass_validation(state_def: t.Dict[str, t.Any]):
+    state_model = FailState(**state_def)
+    state_def_out = state_model.dict(exclude_unset=True)
+    assert state_def_out == state_def
 
 
-@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
-def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+@pytest.mark.parametrize("state_def", invalid_state_definitions)
+def test_invalid_fail_states_fail_validation(state_def: t.Dict[str, t.Any]):
     with pytest.raises(FlowValidationError) as ve:
-        FlowDefinition(**flow_def)
+        FailState(**state_def)
 
     assert ve.type is FlowValidationError

--- a/tests/flow_validation/test_flow_top_level.py
+++ b/tests/flow_validation/test_flow_top_level.py
@@ -1,0 +1,77 @@
+import typing as t
+
+import pytest
+
+from globus_automate_client.models import FlowDefinition, FlowValidationError
+
+expected_top_level_fields = {
+    "StartAt": "SimplePass",
+    "Comment": "This is allowed",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "Parameters": {},
+            "End": True,
+        },
+    },
+}
+
+
+unexpected_top_level_fields = {
+    "StartAt": "SimplePass",
+    "Comment": "This is allowed",
+    "SomeCustomField": "This is disallowed",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "Parameters": {},
+            "End": True,
+        },
+    },
+}
+
+missing_start_at_field = {
+    "Comment": "This is allowed",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "Parameters": {},
+            "End": True,
+        },
+    },
+}
+
+missing_states_field = {
+    "StartAt": "SimplePass",
+    "Comment": "This is allowed",
+}
+
+missing_start_at_and_states_fields = {
+    "Comment": "This is allowed",
+}
+
+empty_flow_definition: t.Dict[str, str] = {}
+
+valid_flow_definitions = [expected_top_level_fields]
+invalid_flow_definitions = [
+    unexpected_top_level_fields,
+    missing_start_at_field,
+    missing_states_field,
+    empty_flow_definition,
+    missing_start_at_and_states_fields,
+]
+
+
+@pytest.mark.parametrize("flow_def", valid_flow_definitions)
+def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
+    flow_model = FlowDefinition(**flow_def)
+    flow_def_out = flow_model.dict(exclude_unset=True)
+    assert flow_def_out == flow_def
+
+
+@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
+def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+    with pytest.raises(FlowValidationError) as ve:
+        FlowDefinition(**flow_def)
+
+    assert ve.type is FlowValidationError

--- a/tests/flow_validation/test_flow_top_level.py
+++ b/tests/flow_validation/test_flow_top_level.py
@@ -16,7 +16,6 @@ expected_top_level_fields = {
     },
 }
 
-
 unexpected_top_level_fields = {
     "StartAt": "SimplePass",
     "Comment": "This is allowed",

--- a/tests/flow_validation/test_pass_state.py
+++ b/tests/flow_validation/test_pass_state.py
@@ -2,85 +2,52 @@ import typing as t
 
 import pytest
 
-from globus_automate_client.models import FlowDefinition, FlowValidationError
+from globus_automate_client.models import FlowValidationError, PassState
 
 valid_pass_state_usage = {
-    "StartAt": "SimplePass",
-    "States": {
-        "SimplePass": {
-            "Type": "Pass",
-            "End": True,
-        },
-    },
+    "Type": "Pass",
+    "End": True,
 }
 
 input_path_is_not_json_path = {
-    "StartAt": "SimplePass",
-    "States": {
-        "SimplePass": {
-            "Type": "Pass",
-            "InputPath": "not_a_json_path",
-            "End": True,
-        },
-    },
+    "Type": "Pass",
+    "InputPath": "not_a_json_path",
+    "End": True,
 }
+
 result_is_not_json_path = {
-    "StartAt": "SimplePass",
-    "States": {
-        "SimplePass": {
-            "Type": "Pass",
-            "Result": "not_a_json_path",
-            "End": True,
-        },
-    },
+    "Type": "Pass",
+    "Result": "not_a_json_path",
+    "End": True,
 }
+
 result_path_is_not_json_path = {
-    "StartAt": "SimplePass",
-    "States": {
-        "SimplePass": {
-            "Type": "Pass",
-            "ResultPath": "not_a_json_path",
-            "End": True,
-        },
-    },
+    "Type": "Pass",
+    "ResultPath": "not_a_json_path",
+    "End": True,
 }
 
 parameter_key_is_json_path_values_are_not_json_path = {
-    "StartAt": "SimplePass",
-    "States": {
-        "SimplePass": {
-            "Type": "Pass",
-            "Parameters": {"json_path_key.$": "not_a_json_path"},
-            "End": True,
-        },
-    },
+    "Type": "Pass",
+    "Parameters": {"json_path_key.$": "not_a_json_path"},
+    "End": True,
 }
 
 nested_parameter_key_is_json_path_values_are_not_json_path = {
-    "StartAt": "SimplePass",
-    "States": {
-        "SimplePass": {
-            "Type": "Pass",
-            "Parameters": {"nested_json": {"json_path_key.$": "not_a_json_path"}},
-            "End": True,
-        },
-    },
+    "Type": "Pass",
+    "Parameters": {"nested_json": {"json_path_key.$": "not_a_json_path"}},
+    "End": True,
 }
 
 additional_fields_set_on_state = {
-    "StartAt": "SimplePass",
-    "States": {
-        "SimplePass": {
-            "Type": "Pass",
-            "Parameters": {},
-            "NonExistantStateField": True,
-            "End": True,
-        },
-    },
+    "Type": "Pass",
+    "Parameters": {},
+    "NonExistantStateField": True,
+    "End": True,
 }
 
-valid_flow_definitions = [valid_pass_state_usage]
-invalid_flow_definitions = [
+valid_state_definitions = [valid_pass_state_usage]
+invalid_state_definitions = [
     input_path_is_not_json_path,
     result_is_not_json_path,
     result_path_is_not_json_path,
@@ -90,16 +57,16 @@ invalid_flow_definitions = [
 ]
 
 
-@pytest.mark.parametrize("flow_def", valid_flow_definitions)
-def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    flow_model = FlowDefinition(**flow_def)
-    flow_def_out = flow_model.dict(exclude_unset=True)
-    assert flow_def_out == flow_def
+@pytest.mark.parametrize("state_def", valid_state_definitions)
+def test_valid_pass_states_pass_validation(state_def: t.Dict[str, t.Any]):
+    state_model = PassState(**state_def)
+    state_def_out = state_model.dict(exclude_unset=True)
+    assert state_def_out == state_def
 
 
-@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
-def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+@pytest.mark.parametrize("state_def", invalid_state_definitions)
+def test_invalid_pass_states_fail_validation(state_def: t.Dict[str, t.Any]):
     with pytest.raises(FlowValidationError) as ve:
-        FlowDefinition(**flow_def)
+        PassState(**state_def)
 
     assert ve.type is FlowValidationError

--- a/tests/flow_validation/test_pass_state.py
+++ b/tests/flow_validation/test_pass_state.py
@@ -103,5 +103,3 @@ def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
         FlowDefinition(**flow_def)
 
     assert ve.type is FlowValidationError
-    # Assert that we're only triggering the Exception under test
-    # assert len(ve.value.errors()) == 1

--- a/tests/flow_validation/test_pass_state.py
+++ b/tests/flow_validation/test_pass_state.py
@@ -92,7 +92,9 @@ invalid_flow_definitions = [
 
 @pytest.mark.parametrize("flow_def", valid_flow_definitions)
 def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    FlowDefinition(**flow_def)
+    flow_model = FlowDefinition(**flow_def)
+    flow_def_out = flow_model.dict(exclude_unset=True)
+    assert flow_def_out == flow_def
 
 
 @pytest.mark.parametrize("flow_def", invalid_flow_definitions)

--- a/tests/flow_validation/test_pass_state.py
+++ b/tests/flow_validation/test_pass_state.py
@@ -1,0 +1,105 @@
+import typing as t
+
+import pytest
+
+from globus_automate_client.models import FlowDefinition, FlowValidationError
+
+valid_pass_state_usage = {
+    "StartAt": "SimplePass",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "End": True,
+        },
+    },
+}
+
+input_path_is_not_json_path = {
+    "StartAt": "SimplePass",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "InputPath": "not_a_json_path",
+            "End": True,
+        },
+    },
+}
+result_is_not_json_path = {
+    "StartAt": "SimplePass",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "Result": "not_a_json_path",
+            "End": True,
+        },
+    },
+}
+result_path_is_not_json_path = {
+    "StartAt": "SimplePass",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "ResultPath": "not_a_json_path",
+            "End": True,
+        },
+    },
+}
+
+parameter_key_is_json_path_values_are_not_json_path = {
+    "StartAt": "SimplePass",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "Parameters": {"json_path_key.$": "not_a_json_path"},
+            "End": True,
+        },
+    },
+}
+
+nested_parameter_key_is_json_path_values_are_not_json_path = {
+    "StartAt": "SimplePass",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "Parameters": {"nested_json": {"json_path_key.$": "not_a_json_path"}},
+            "End": True,
+        },
+    },
+}
+
+additional_fields_set_on_state = {
+    "StartAt": "SimplePass",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "Parameters": {},
+            "NonExistantStateField": True,
+            "End": True,
+        },
+    },
+}
+
+valid_flow_definitions = [valid_pass_state_usage]
+invalid_flow_definitions = [
+    input_path_is_not_json_path,
+    result_is_not_json_path,
+    result_path_is_not_json_path,
+    parameter_key_is_json_path_values_are_not_json_path,
+    nested_parameter_key_is_json_path_values_are_not_json_path,
+    additional_fields_set_on_state,
+]
+
+
+@pytest.mark.parametrize("flow_def", valid_flow_definitions)
+def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
+    FlowDefinition(**flow_def)
+
+
+@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
+def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+    with pytest.raises(FlowValidationError) as ve:
+        FlowDefinition(**flow_def)
+
+    assert ve.type is FlowValidationError
+    # Assert that we're only triggering the Exception under test
+    # assert len(ve.value.errors()) == 1

--- a/tests/flow_validation/test_transitions.py
+++ b/tests/flow_validation/test_transitions.py
@@ -164,7 +164,9 @@ invalid_flow_definitions = [
 
 @pytest.mark.parametrize("flow_def", valid_flow_definitions)
 def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    FlowDefinition(**flow_def)
+    flow_model = FlowDefinition(**flow_def)
+    flow_def_out = flow_model.dict(exclude_unset=True)
+    assert flow_def_out == flow_def
 
 
 @pytest.mark.parametrize("flow_def", invalid_flow_definitions)

--- a/tests/flow_validation/test_transitions.py
+++ b/tests/flow_validation/test_transitions.py
@@ -1,0 +1,176 @@
+import typing as t
+
+import pytest
+
+from globus_automate_client.models import FlowDefinition, FlowValidationError
+
+valid_start_state = {
+    "StartAt": "SimplePass",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "End": True,
+        },
+    },
+}
+
+non_existant_start_state = {
+    "StartAt": "DoesNotExistAsAState",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "End": True,
+        },
+    },
+}
+
+non_existant_next_state = {
+    "StartAt": "DoesNotExistAsAState",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "Next": "SimplePass2",
+        },
+        "SimplePass2": {
+            "Type": "Pass",
+            "End": True,
+        },
+    },
+}
+
+multiple_end_states_defined = {
+    "StartAt": "SimplePass",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "End": True,
+        },
+        "SimplePass2": {
+            "Type": "Pass",
+            "End": True,
+        },
+    },
+}
+
+both_next_and_end_states_defined = {
+    "StartAt": "SimplePass",
+    "States": {
+        "SimplePass": {
+            "Type": "Pass",
+            "Comment": "both_next_and_end_states_defined",
+            "Next": "SimplePass2",
+            "End": True,
+        },
+    },
+}
+
+action_catch_refers_to_nonexistent_state = {
+    "StartAt": "SimpleAction",
+    "States": {
+        "SimpleAction": {
+            "Type": "Action",
+            "ActionUrl": "https://actions.automate.globus.org/hello_world",
+            "Parameters": {},
+            "Catch": [
+                {
+                    "ErrorEquals": ["SomeError"],
+                    "Next": "NotAState",
+                }
+            ],
+            "End": True,
+        },
+    },
+}
+
+choice_state_default_refers_to_nonexistent_state = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Default": "NotAState",
+            "Choices": [
+                {
+                    "Variable": "$.some_variable",
+                    "BooleanEquals": False,
+                    "Next": "FinalState",
+                }
+            ],
+        },
+        "FinalState": {
+            "Type": "Pass",
+            "End": True,
+        },
+    },
+}
+
+choice_state_rule_refers_to_nonexistent_state = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Default": "FinalState",
+            "Choices": [
+                {
+                    "Variable": "$.some_variable",
+                    "BooleanEquals": False,
+                    "Next": "NotAState",
+                }
+            ],
+        },
+        "FinalState": {
+            "Type": "Pass",
+            "End": True,
+        },
+    },
+}
+
+unreferenced_state_defined = {
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Default": "FinalState",
+            "Choices": [
+                {
+                    "Variable": "$.some_variable",
+                    "BooleanEquals": False,
+                    "Next": "NotAState",
+                }
+            ],
+        },
+        "SuperfluousState": {
+            "Type": "Pass",
+            "Next": "FinalState",
+        },
+        "FinalState": {
+            "Type": "Pass",
+            "End": True,
+        },
+    },
+}
+
+valid_flow_definitions = [valid_start_state]
+invalid_flow_definitions = [
+    non_existant_start_state,
+    non_existant_next_state,
+    multiple_end_states_defined,
+    both_next_and_end_states_defined,
+    action_catch_refers_to_nonexistent_state,
+    choice_state_default_refers_to_nonexistent_state,
+    choice_state_rule_refers_to_nonexistent_state,
+    unreferenced_state_defined,
+]
+
+
+@pytest.mark.parametrize("flow_def", valid_flow_definitions)
+def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
+    FlowDefinition(**flow_def)
+
+
+@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
+def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+    with pytest.raises(FlowValidationError) as ve:
+        FlowDefinition(**flow_def)
+
+    assert ve.type is FlowValidationError
+    # Assert that we're only triggering the Exception under test

--- a/tests/flow_validation/test_wait_state.py
+++ b/tests/flow_validation/test_wait_state.py
@@ -116,7 +116,9 @@ invalid_flow_definitions = [
 
 @pytest.mark.parametrize("flow_def", valid_flow_definitions)
 def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    FlowDefinition(**flow_def)
+    flow_model = FlowDefinition(**flow_def)
+    flow_def_out = flow_model.dict(exclude_unset=True)
+    assert flow_def_out == flow_def
 
 
 @pytest.mark.parametrize("flow_def", invalid_flow_definitions)

--- a/tests/flow_validation/test_wait_state.py
+++ b/tests/flow_validation/test_wait_state.py
@@ -1,0 +1,127 @@
+import typing as t
+
+import pytest
+
+from globus_automate_client.models import FlowDefinition, FlowValidationError
+
+valid_wait_state = {
+    "StartAt": "SimpleWait",
+    "States": {
+        "SimpleWait": {
+            "Type": "Wait",
+            "Comment": "Simply Waiting",
+            "Seconds": 1,
+            "End": True,
+        },
+    },
+}
+
+
+multiple_wait_time_fields_set = {
+    "StartAt": "SimpleWait",
+    "States": {
+        "SimpleWait": {
+            "Type": "Wait",
+            "Comment": "Simply Waiting",
+            "Seconds": 1,
+            "SecondsPath": "$.some_path",
+            "End": True,
+        },
+    },
+}
+
+no_wait_time_fields_set = {
+    "StartAt": "SimpleWait",
+    "States": {
+        "SimpleWait": {
+            "Type": "Wait",
+            "Comment": "Simply Waiting",
+            "End": True,
+        },
+    },
+}
+
+unexpected_fields_set = {
+    "StartAt": "SimpleWait",
+    "States": {
+        "SimpleWait": {
+            "Type": "Wait",
+            "Comment": "Simply Waiting",
+            "Seconds": 1,
+            "ThisFieldIsUnexpected": True,
+            "End": True,
+        },
+    },
+}
+
+
+input_path_is_not_json_path = {
+    "StartAt": "SimpleWait",
+    "States": {
+        "SimpleWait": {
+            "Type": "Wait",
+            "Comment": "Simply Waiting",
+            "Seconds": 2,
+            "InputPath": "not_json_path",
+            "End": True,
+        },
+    },
+}
+output_path_is_not_json_path = {
+    "StartAt": "SimpleWait",
+    "States": {
+        "SimpleWait": {
+            "Type": "Wait",
+            "Comment": "Simply Waiting",
+            "Seconds": 1,
+            "OutputPath": "not_json_path",
+            "End": True,
+        },
+    },
+}
+seconds_path_is_not_json_path = {
+    "StartAt": "SimpleWait",
+    "States": {
+        "SimpleWait": {
+            "Type": "Wait",
+            "Comment": "Simply Waiting",
+            "SecondsPath": "not_json_path",
+            "End": True,
+        },
+    },
+}
+timestamp_path_is_not_json_path = {
+    "StartAt": "SimpleWait",
+    "States": {
+        "SimpleWait": {
+            "Type": "Wait",
+            "Comment": "Simply Waiting",
+            "TimestampPath": "not_json_path",
+            "End": True,
+        },
+    },
+}
+
+valid_flow_definitions = [valid_wait_state]
+invalid_flow_definitions = [
+    multiple_wait_time_fields_set,
+    no_wait_time_fields_set,
+    unexpected_fields_set,
+    input_path_is_not_json_path,
+    output_path_is_not_json_path,
+    seconds_path_is_not_json_path,
+    timestamp_path_is_not_json_path,
+]
+
+
+@pytest.mark.parametrize("flow_def", valid_flow_definitions)
+def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
+    FlowDefinition(**flow_def)
+
+
+@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
+def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+    with pytest.raises(FlowValidationError) as ve:
+        FlowDefinition(**flow_def)
+
+    assert ve.type is FlowValidationError

--- a/tests/flow_validation/test_wait_state.py
+++ b/tests/flow_validation/test_wait_state.py
@@ -2,108 +2,70 @@ import typing as t
 
 import pytest
 
-from globus_automate_client.models import FlowDefinition, FlowValidationError
+from globus_automate_client.models import FlowValidationError, WaitState
 
 valid_wait_state = {
-    "StartAt": "SimpleWait",
-    "States": {
-        "SimpleWait": {
-            "Type": "Wait",
-            "Comment": "Simply Waiting",
-            "Seconds": 1,
-            "End": True,
-        },
-    },
+    "Type": "Wait",
+    "Comment": "Simply Waiting",
+    "Seconds": 1,
+    "End": True,
 }
 
-
 multiple_wait_time_fields_set = {
-    "StartAt": "SimpleWait",
-    "States": {
-        "SimpleWait": {
-            "Type": "Wait",
-            "Comment": "Simply Waiting",
-            "Seconds": 1,
-            "SecondsPath": "$.some_path",
-            "End": True,
-        },
-    },
+    "Type": "Wait",
+    "Comment": "Simply Waiting",
+    "Seconds": 1,
+    "SecondsPath": "$.some_path",
+    "End": True,
 }
 
 no_wait_time_fields_set = {
-    "StartAt": "SimpleWait",
-    "States": {
-        "SimpleWait": {
-            "Type": "Wait",
-            "Comment": "Simply Waiting",
-            "End": True,
-        },
-    },
+    "Type": "Wait",
+    "Comment": "Simply Waiting",
+    "End": True,
 }
 
 unexpected_fields_set = {
-    "StartAt": "SimpleWait",
-    "States": {
-        "SimpleWait": {
-            "Type": "Wait",
-            "Comment": "Simply Waiting",
-            "Seconds": 1,
-            "ThisFieldIsUnexpected": True,
-            "End": True,
-        },
-    },
+    "Type": "Wait",
+    "Comment": "Simply Waiting",
+    "Seconds": 1,
+    "ThisFieldIsUnexpected": True,
+    "End": True,
 }
-
 
 input_path_is_not_json_path = {
-    "StartAt": "SimpleWait",
-    "States": {
-        "SimpleWait": {
-            "Type": "Wait",
-            "Comment": "Simply Waiting",
-            "Seconds": 2,
-            "InputPath": "not_json_path",
-            "End": True,
-        },
-    },
-}
-output_path_is_not_json_path = {
-    "StartAt": "SimpleWait",
-    "States": {
-        "SimpleWait": {
-            "Type": "Wait",
-            "Comment": "Simply Waiting",
-            "Seconds": 1,
-            "OutputPath": "not_json_path",
-            "End": True,
-        },
-    },
-}
-seconds_path_is_not_json_path = {
-    "StartAt": "SimpleWait",
-    "States": {
-        "SimpleWait": {
-            "Type": "Wait",
-            "Comment": "Simply Waiting",
-            "SecondsPath": "not_json_path",
-            "End": True,
-        },
-    },
-}
-timestamp_path_is_not_json_path = {
-    "StartAt": "SimpleWait",
-    "States": {
-        "SimpleWait": {
-            "Type": "Wait",
-            "Comment": "Simply Waiting",
-            "TimestampPath": "not_json_path",
-            "End": True,
-        },
-    },
+    "Type": "Wait",
+    "Comment": "Simply Waiting",
+    "Seconds": 2,
+    "InputPath": "not_json_path",
+    "End": True,
 }
 
-valid_flow_definitions = [valid_wait_state]
-invalid_flow_definitions = [
+output_path_is_not_json_path = {
+    "Type": "Wait",
+    "Comment": "Simply Waiting",
+    "Seconds": 1,
+    "OutputPath": "not_json_path",
+    "End": True,
+}
+
+seconds_path_is_not_json_path = {
+    "Type": "Wait",
+    "Comment": "Simply Waiting",
+    "SecondsPath": "not_json_path",
+    "End": True,
+}
+
+timestamp_path_is_not_json_path = {
+    "Type": "Wait",
+    "Comment": "Simply Waiting",
+    "TimestampPath": "not_json_path",
+    "End": True,
+}
+
+
+valid_state_definitions = [valid_wait_state]
+invalid_state_definitions = [
     multiple_wait_time_fields_set,
     no_wait_time_fields_set,
     unexpected_fields_set,
@@ -114,16 +76,16 @@ invalid_flow_definitions = [
 ]
 
 
-@pytest.mark.parametrize("flow_def", valid_flow_definitions)
-def test_valid_flows_pass_validation(flow_def: t.Dict[str, t.Any]):
-    flow_model = FlowDefinition(**flow_def)
-    flow_def_out = flow_model.dict(exclude_unset=True)
-    assert flow_def_out == flow_def
+@pytest.mark.parametrize("state_def", valid_state_definitions)
+def test_valid_wait_states_pass_validation(state_def: t.Dict[str, t.Any]):
+    state_model = WaitState(**state_def)
+    state_def_out = state_model.dict(exclude_unset=True)
+    assert state_def_out == state_def
 
 
-@pytest.mark.parametrize("flow_def", invalid_flow_definitions)
-def test_invalid_flows_fail_validation(flow_def: t.Dict[str, t.Any]):
+@pytest.mark.parametrize("state_def", invalid_state_definitions)
+def test_invalid_wait_states_fail_validation(state_def: t.Dict[str, t.Any]):
     with pytest.raises(FlowValidationError) as ve:
-        FlowDefinition(**flow_def)
+        WaitState(**state_def)
 
     assert ve.type is FlowValidationError


### PR DESCRIPTION
- Introduces models for defining the relationships and constraints
  for the different state types in Step Functions
- Adds tests validating the models for a given state type
- Re-purposes FlowValidationError to reflect pydantic's
  ValidationError
- Creates a separate FlowSchemaValidationError which is raised when
  validating input schemas.
  
The tests I added also run on the sample Flow definitions in the examples directory. I used those to make sure the validation was working correctly and then the unit tests for each individual Flow state type make sure that the expected failures are triggered.

This is a list of the validation that happens:

### General
- enforces that Parameters with keys ending in JSONPath syntax have values
  beginning with JSONPath syntax
- enforces that Parameters with key values starting in JSONPath syntax have keys
  ending in JSONPath syntax
- enforces boolean fields are either True or False with no boolean
  interpretation
- enforces data types (booleans are booleans, objects are dicts, strings are
  strings, ints are ints)
- prevents bogus fields from getting set on states
- enforces fields that are JSONPaths (such as ResultPath) begin with “$.”

### Flow definition validation
- enforces that startAt is a defined state
- enforces that all “next” states defined in states exist
- enforces that an Action state’s “Catch” conditions refer to an existing state
- enforces that a Choice state’s default condition refers to an existing state
- enforces that a Choice state’s rules contain references to existing states
- enforces that transition states only define a Next or End.
- enforces that all defined states can be reached
- enforces that all state names are between 1 and 128 characters inclusive

### Pass State validation
- enforces that InputPath Result and ResultPath are JSONPaths
- enforces that JSONPath keys in parameters are matched with JSONPath values
- prevents additional properties from getting set

### Wait State validation
- enforces that WaitState’s InputPath, OutputPath, SecondsPath, and
  TimestampPath are JSONPaths
- enforces that exactly one of WaitState’s time fields are set
- prevents additional properties from getting set

### Fail State validation
- prevents additional properties from getting set

### ExpressionEval validation
- enforces that ResultPath is a JSONPath
- enforces that JSONPath keys in parameters are matched with JSONPath values
- prevents additional properties from getting set

### ActionState validation
- enforces that InputPath and ResultPath are JSONPaths
- enforces that JSONPath keys in parameters are matched with JSONPath values
- enforces that exactly one of InputPath or Parameters is set
- enforces that the ActionURL is an HttpUrl
- enforces that a Catcher’s ResultPath is a JSONPath
- enforces that a Catcher’s ErrorEquals list is non-empty
- prevents additional properties from getting set

### ChoiceState validation
- enforces that the Choices list is non-empty
- enforces that an And or Or boolean expression contain at least one rule
- enforces that ChoiceRule path variables are JSONPaths
- enforces that only valid ComparisonOperators are used within ChoiceRules
- enforces that only one ComparisonOperator is used within a ChoiceRule
- enforces that BooleanExpressions contain at least one ChoiceRule
- prevents additional properties from getting set