### PR TITLE
Transfer label and destination endpoint incorrect

### DIFF
--- a/examples/flows/transfer-mv-yaml/sample_input.yaml
+++ b/examples/flows/transfer-mv-yaml/sample_input.yaml
@@ -1,8 +1,8 @@
 source_endpoint_id: ddb59aef-6d04-11e5-ba46-22000b92c6ec
 source_path: /~/source_folder
-destination_endpoint_id: 25974dc2-fc46-11e9-9947-0a8c187e8c12
+destination_endpoint_id: ddb59af0-6d04-11e5-ba46-22000b92c6ec
 destination_path: /~/destination_folder
-transfer_label: Transfer for Move from go#ep1 to go#ep2
+transfer_label: Transfer for Move from go_ep1 to go_ep2
 delete_label: Remove after Transfer for Move operation
 recursive: true
 sync_level: '0'

--- a/examples/flows/transfer-mv/sample_input.json
+++ b/examples/flows/transfer-mv/sample_input.json
@@ -1,9 +1,9 @@
 {
   "source_endpoint_id": "ddb59aef-6d04-11e5-ba46-22000b92c6ec",
   "source_path": "/~/source_folder",
-  "destination_endpoint_id": "25974dc2-fc46-11e9-9947-0a8c187e8c12",
+  "destination_endpoint_id": "ddb59af0-6d04-11e5-ba46-22000b92c6ec",
   "destination_path": "/~/destination_folder",
-  "transfer_label": "Transfer for Move from go#ep1 to go#ep2",
+  "transfer_label": "Transfer for Move from go_ep1 to go_ep2",
   "delete_label": "Remove after Transfer for Move operation",
   "recursive": true,
   "sync_level": "0"


### PR DESCRIPTION
This is Jim's work. The bugs still exist in `main` so let's review and merge this PR.

Comment from the commit:

>The description says we're going from go#ep1 to go#ep2, but in fact
>the destination endpoint id was not for go#ep2.
>
>Also, the use of the hash in the label is not allowed so changed that
>to an underscore.

