### PR TITLE
Standardize JSON files in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,5 +26,5 @@ indent_size = 2
 [Makefile]
 indent_style = tab
 
-[{package,package-lock}.json]
+[*.json]
 indent_size = 2


### PR DESCRIPTION
Now all `.json` files will use 2 spaces.