### PR TITLE
Fix tabular `run-list` output

### DIFF
--- a/changelog.d/20220307_084347_kurtmckee_fix_tabular_run_list_output.rst
+++ b/changelog.d/20220307_084347_kurtmckee_fix_tabular_run_list_output.rst
@@ -1,0 +1,5 @@
+Bugfixes
+--------
+
+-   `[sc-13664] <https://app.shortcut.com/globus/story/13664/>`_
+    Fix tabular ``run-list`` output.

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -36,7 +36,6 @@ from globus_automate_client.cli.rich_helpers import (
     FlowListDisplayFields,
     LogCompletionDetector,
     RequestRunner,
-    RunEnumerateDisplayFields,
     RunListDisplayFields,
     RunLogDisplayFields,
 )
@@ -1144,7 +1143,7 @@ def flow_action_enumerate(
             format=output_format,
             verbose=verbose,
             watch=watch,
-            fields=RunEnumerateDisplayFields,
+            fields=RunListDisplayFields,
         ).run_and_render()
 
 

--- a/globus_automate_client/cli/rich_helpers.py
+++ b/globus_automate_client/cli/rich_helpers.py
@@ -128,17 +128,8 @@ class RunListDisplayFields(DisplayFields):
         Field("created_by", "", humanize_auth_urn),
         Field("flow_id", "<DELETED>"),
     ]
-    path_to_data_list = "actions"
-    prehook = functools.partial(identity_to_user, "created_by")
-
-
-class RunEnumerateDisplayFields(RunListDisplayFields):
-    """
-    This object defines the fields and display style of a Run enumeration into a
-    table.
-    """
-
     path_to_data_list = "runs"
+    prehook = functools.partial(identity_to_user, "created_by")
 
 
 class FlowListDisplayFields(DisplayFields):

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -937,7 +937,7 @@ class FlowsClient(BaseClient):
 
         authorizer = self._get_authorizer_for_flow(flow_id, flow_scope, kwargs)
         with self.use_temporary_authorizer(authorizer):
-            return self.get(f"/flows/{flow_id}/actions", query_params=params, **kwargs)
+            return self.get(f"/flows/{flow_id}/runs", query_params=params, **kwargs)
 
     def flow_action_update(
         self,

--- a/tests/test_flows_client.py
+++ b/tests/test_flows_client.py
@@ -772,7 +772,7 @@ def test_list_flow_runs_role_precedence(
 ):
     """Verify the *role* and *roles* precedence rules."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/actions")
+    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/runs")
     fc.list_flow_runs(
         "-",
         role=role,
@@ -808,7 +808,7 @@ def test_list_flow_runs_pagination_parameters(
 ):
     """Verify *marker* and *per_page* precedence rules."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/actions")
+    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/runs")
     fc.list_flow_runs(
         "-",
         marker=marker,
@@ -828,7 +828,7 @@ def test_list_flow_runs_pagination_parameters(
 def test_list_flow_runs_filters(fc, mocked_responses):
     """Verify that filters are applied to the query parameters."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/actions")
+    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/runs")
     fc.list_flow_runs(
         "-",
         role="role",
@@ -844,7 +844,7 @@ def test_list_flow_runs_filters(fc, mocked_responses):
 def test_list_flow_runs_orderings(fc, mocked_responses):
     """Verify that orderings are serialized as expected."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/actions")
+    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/runs")
     fc.list_flow_runs(
         "-",
         orderings={"shape": "asc", "color": "DESC", "bogus": "bad"},
@@ -862,7 +862,7 @@ def test_list_flow_runs_orderings(fc, mocked_responses):
 def test_list_flow_runs_statuses(fc, mocked_responses):
     """Verify that orderings are serialized as expected."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/actions")
+    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/runs")
     fc.list_flow_runs(
         "-",
         statuses=("SUCCEEDED", "FAILED"),


### PR DESCRIPTION
The root cause is that `run-enumerate` and `run-list` anticipate different top-level JSON object keys (`"runs"` and `"actions"`, respectively) but the `run-list` command calls the same function as `run-enumerate` if no `--flow-id` is specified.

The mismatch of anticipated top-level keys prevented `run-list` from finding results to present in tabular form.

Notably, changing the URL route from `.../actions` to `.../runs` changes the top-level key name, too.

JSON and YAML output formats were not affected.