### PR TITLE
Removing reference to 'Timer CLI'

### DIFF
--- a/changelog.d/20220310_131513_jimPruyne_timer_cli_named_in_error_string.rst
+++ b/changelog.d/20220310_131513_jimPruyne_timer_cli_named_in_error_string.rst
@@ -1,0 +1,19 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Features
+.. --------
+..
+.. - A bullet item for the Features category.
+..
+Bugfixes
+--------
+
+- Changed text on improper token cache file condition so that it doesn't reference the Timer CLI
+..
+.. Documentation
+.. -------------
+..
+.. - A bullet item for the Documentation category.
+..

--- a/globus_automate_client/cli/auth.py
+++ b/globus_automate_client/cli/auth.py
@@ -137,8 +137,8 @@ class TokenCache:
             pass
         except JSONDecodeError:
             raise EnvironmentError(
-                "Token cache for Timer CLI is corrupted; please run a `session revoke`"
-                " and try again"
+                "Token cache is corrupted; please run `session revoke` or remove "
+                f"file {self.token_store} and try again"
             )
 
     @staticmethod


### PR DESCRIPTION
This error string is printed when the token cache file doesn't parse
as proper JSON.
