### PR TITLE
Support batch run updates

### DIFF
--- a/changelog.d/20220315_143000_kurtmckee_batch_run_updates_sc_12888.rst
+++ b/changelog.d/20220315_143000_kurtmckee_batch_run_updates_sc_12888.rst
@@ -1,7 +1,9 @@
 Features
 --------
 
+-   `[sc-13426] <https://app.shortcut.com/globus/story/13426>`_
+    Support setting tags when using the ``flow run`` subcommand.
 -   Support batch updates of one or more Runs.
--   Support updating tags and labels using the ``run-update`` subcommand.
--   Support erasing the list of Run managers and Run monitors using the ``run-update`` subcommand.
+-   Support updating tags and labels using the ``flow run-update`` subcommand.
+-   Support erasing the list of Run managers and Run monitors using the ``flow run-update`` subcommand.
     This can be done by specifying an empty string for the value of the ``--run-manager`` and ``--run-monitor`` options.

--- a/changelog.d/20220315_143000_kurtmckee_batch_run_updates_sc_12888.rst
+++ b/changelog.d/20220315_143000_kurtmckee_batch_run_updates_sc_12888.rst
@@ -1,6 +1,7 @@
 Features
 --------
 
+-   Support batch updates of one or more Runs.
 -   Support updating tags and labels using the ``run-update`` subcommand.
 -   Support erasing the list of Run managers and Run monitors using the ``run-update`` subcommand.
     This can be done by specifying an empty string for the value of the ``--run-manager`` and ``--run-monitor`` options.

--- a/changelog.d/20220315_143000_kurtmckee_batch_run_updates_sc_12888.rst
+++ b/changelog.d/20220315_143000_kurtmckee_batch_run_updates_sc_12888.rst
@@ -1,0 +1,6 @@
+Features
+--------
+
+-   Support updating tags and labels using the ``run-update`` subcommand.
+-   Support erasing the list of Run managers and Run monitors using the ``run-update`` subcommand.
+    This can be done by specifying an empty string for the value of the ``--run-manager`` and ``--run-monitor`` options.

--- a/globus_automate_client/action_client.py
+++ b/globus_automate_client/action_client.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, Dict, Iterable, Mapping, Optional, Type, TypeVar, Union
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Type, TypeVar, Union
 from urllib.parse import quote
 
 from globus_sdk import BaseClient, GlobusHTTPResponse
@@ -52,6 +52,7 @@ class ActionClient(BaseClient):
         manage_by: Optional[Iterable[str]] = None,
         monitor_by: Optional[Iterable[str]] = None,
         label: Optional[str] = None,
+        tags: Optional[List[str]] = None,
         force_path: Optional[str] = None,
         **kwargs,
     ) -> GlobusHTTPResponse:
@@ -74,6 +75,7 @@ class ActionClient(BaseClient):
         :param force_path: A URL to use for running this action, ignoring any
             previous configuration
         :param label: Set a label for the Action that is run.
+        :param tags: A list of tags to associate with the Run.
         :param run_monitors: May be used as an alias for ``monitor_by``
         :param run_managers: May be used as an alias for ``manage_by``
         """
@@ -89,6 +91,7 @@ class ActionClient(BaseClient):
             "monitor_by": merge_keywords(monitor_by, kwargs, "run_monitors"),
             "manage_by": merge_keywords(manage_by, kwargs, "run_managers"),
             "label": label,
+            "tags": tags,
         }
         # Remove None items from the temp_body
         data = {k: v for k, v in body.items() if v is not None}

--- a/globus_automate_client/cli/callbacks.py
+++ b/globus_automate_client/cli/callbacks.py
@@ -91,18 +91,6 @@ def custom_principal_validator(special_values: AbstractSet[str]) -> Callable:
     return wrapper
 
 
-def principal_or_all_authenticated_users_validator(principals: List[str]) -> List[str]:
-    """
-    Certain fields expect values to be a valid Globus Auth UUID or one of a set
-    of special strings that are meaningful in the context of authentication.
-    This callback is a specialized form of the principal_validator where the
-    special value of 'all_authenticated_users' is accepted.
-    """
-    return _base_principal_validator(
-        principals, special_vals={"all_authenticated_users"}
-    )
-
-
 def principal_or_public_validator(principals: List[str]) -> List[str]:
     """
     Certain fields expect values to be a valid Globus Auth UUID or one of a set

--- a/globus_automate_client/cli/callbacks.py
+++ b/globus_automate_client/cli/callbacks.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 import re
 from errno import ENAMETOOLONG
-from typing import AbstractSet, List, Optional
+from typing import AbstractSet, Callable, List, Optional, cast
 from urllib.parse import urlparse
 
 import typer
@@ -77,10 +77,18 @@ def _base_principal_validator(
 
 
 def principal_validator(principals: List[str]) -> List[str]:
-    """
-    A principal ID needs to be a valid UUID.
-    """
-    return _base_principal_validator(principals)
+    """A principal ID needs to be a valid UUID."""
+
+    return _base_principal_validator(cast(List[str], principals))
+
+
+def custom_principal_validator(special_values: AbstractSet[str]) -> Callable:
+    """A principal ID needs to be a valid UUID."""
+
+    def wrapper(principals: List[str]) -> List[str]:
+        return _base_principal_validator(principals, special_vals=special_values)
+
+    return wrapper
 
 
 def principal_or_all_authenticated_users_validator(principals: List[str]) -> List[str]:

--- a/globus_automate_client/cli/callbacks.py
+++ b/globus_automate_client/cli/callbacks.py
@@ -91,16 +91,6 @@ def custom_principal_validator(special_values: AbstractSet[str]) -> Callable:
     return wrapper
 
 
-def principal_or_public_validator(principals: List[str]) -> List[str]:
-    """
-    Certain fields expect values to be a valid Globus Auth UUID or one of a set
-    of special strings that are meaningful in the context of authentication.
-    This callback is a specialized form of the principal_validator where the
-    special value of 'public' is accepted.
-    """
-    return _base_principal_validator(principals, special_vals={"public"})
-
-
 def flows_endpoint_envvar_callback(default_value: str) -> str:
     """
     This callback searches the caller's environment for an environment variable

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -9,7 +9,6 @@ from globus_automate_client.cli.callbacks import (
     custom_principal_validator,
     flow_input_validator,
     input_validator,
-    principal_or_public_validator,
     principal_validator,
     url_validator_callback,
 )
@@ -109,18 +108,18 @@ def flow_deploy(
             + " The special value of 'public' may be used to "
             "indicate that any user can view this Flow. [repeatable]"
         ),
-        callback=principal_or_public_validator,
+        callback=custom_principal_validator({"public"}),
         hidden=False,
     ),
     # viewer and visible_to are aliases for the full flow_viewer
     viewer: List[str] = typer.Option(
         None,
-        callback=principal_or_public_validator,
+        callback=custom_principal_validator({"public"}),
         hidden=True,
     ),
     visible_to: List[str] = typer.Option(
         None,
-        callback=principal_or_public_validator,
+        callback=custom_principal_validator({"public"}),
         hidden=True,
     ),
     flow_starter: List[str] = typer.Option(
@@ -263,13 +262,13 @@ def flow_update(
         + _principal_description
         + "The special value of 'public' may be used to "
         "indicate that any user can view this Flow. [repeatable]",
-        callback=principal_or_public_validator,
+        callback=custom_principal_validator({"public"}),
     ),
     viewer: List[str] = typer.Option(
-        None, callback=principal_or_public_validator, hidden=True
+        None, callback=custom_principal_validator({"public"}), hidden=True
     ),
     visible_to: List[str] = typer.Option(
-        None, callback=principal_or_public_validator, hidden=True
+        None, callback=custom_principal_validator({"public"}), hidden=True
     ),
     flow_starter: List[str] = typer.Option(
         None,

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -616,6 +616,18 @@ def flow_run(
         "-l",
         help="Label to mark this run.",
     ),
+    tags: Optional[List[str]] = typer.Option(
+        None,
+        "--tag",
+        help=dedent(
+            """
+            A tag to associate with this Run.
+
+            This option can be used multiple times.
+            The full collection of tags will associated with the Run.
+            """
+        )
+    ),
     watch: bool = typer.Option(
         False,
         "--watch",
@@ -660,6 +672,7 @@ def flow_run(
         dry_run=dry_run,
         monitor_by=monitor_by,
         manage_by=manage_by,
+        tags=tags,
     )
     with live_content:
         result = RequestRunner(

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -9,7 +9,6 @@ from globus_automate_client.cli.callbacks import (
     custom_principal_validator,
     flow_input_validator,
     input_validator,
-    principal_or_all_authenticated_users_validator,
     principal_or_public_validator,
     principal_validator,
     url_validator_callback,
@@ -133,14 +132,18 @@ def flow_deploy(
             "'all_authenticated_users' may be used to indicate that any authenticated user "
             "can invoke this flow. [repeatable]"
         ),
-        callback=principal_or_all_authenticated_users_validator,
+        callback=custom_principal_validator({"all_authenticated_users"}),
     ),
     # starter and runnable_by are aliases for the full flow_starter
     starter: List[str] = typer.Option(
-        None, callback=principal_or_all_authenticated_users_validator, hidden=True
+        None,
+        callback=custom_principal_validator({"all_authenticated_users"}),
+        hidden=True,
     ),
     runnable_by: List[str] = typer.Option(
-        None, callback=principal_or_all_authenticated_users_validator, hidden=True
+        None,
+        callback=custom_principal_validator({"all_authenticated_users"}),
+        hidden=True,
     ),
     flow_administrator: List[str] = typer.Option(
         None,
@@ -275,13 +278,17 @@ def flow_update(
         + " The special value of "
         "'all_authenticated_users' may be used to indicate that any "
         "authenticated user can invoke this flow. [repeatable]",
-        callback=principal_or_all_authenticated_users_validator,
+        callback=custom_principal_validator({"all_authenticated_users"}),
     ),
     starter: List[str] = typer.Option(
-        None, callback=principal_or_all_authenticated_users_validator, hidden=True
+        None,
+        callback=custom_principal_validator({"all_authenticated_users"}),
+        hidden=True,
     ),
     runnable_by: List[str] = typer.Option(
-        None, callback=principal_or_all_authenticated_users_validator, hidden=True
+        None,
+        callback=custom_principal_validator({"all_authenticated_users"}),
+        hidden=True,
     ),
     flow_administrator: List[str] = typer.Option(
         None,

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -43,22 +43,13 @@ _ENVIRONMENT_FLOWS_BASE_URLS = {
     "staging": "https://staging.flows.automate.globus.org",
 }
 
-MANAGE_FLOWS_SCOPE = (
-    "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/manage_flows"
-)
-VIEW_FLOWS_SCOPE = (
-    "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/view_flows"
-)
-RUN_FLOWS_SCOPE = (
-    "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run"
-)
-RUN_STATUS_SCOPE = (
-    "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run_status"
-)
-RUN_MANAGE_SCOPE = (
-    "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run_manage"
-)
-NULL_SCOPE = "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/null"
+FLOWS_CLIENT_ID = "eec9b274-0c81-4334-bdc2-54e90e689b9a"
+MANAGE_FLOWS_SCOPE = f"https://auth.globus.org/scopes/{FLOWS_CLIENT_ID}/manage_flows"
+VIEW_FLOWS_SCOPE = f"https://auth.globus.org/scopes/{FLOWS_CLIENT_ID}/view_flows"
+RUN_FLOWS_SCOPE = f"https://auth.globus.org/scopes/{FLOWS_CLIENT_ID}/run"
+RUN_STATUS_SCOPE = f"https://auth.globus.org/scopes/{FLOWS_CLIENT_ID}/run_status"
+RUN_MANAGE_SCOPE = f"https://auth.globus.org/scopes/{FLOWS_CLIENT_ID}/run_manage"
+NULL_SCOPE = f"https://auth.globus.org/scopes/{FLOWS_CLIENT_ID}/null"
 
 ALL_FLOW_SCOPES = (
     MANAGE_FLOWS_SCOPE,

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -114,19 +114,21 @@ def _all_vals_for_keys(
 
 
 def validate_flow_definition(flow_definition: Mapping[str, Any]) -> None:
-    """Perform local, JSONSchema based validation of a Flow definition. This is validation
-    on the basic structure of your Flow definition.such as required fields / properties
-    for the various state types and the overall structure of the Flow. This schema based
-    validation *does not* do any validation of input values or parameters passed to
-    Actions as those Actions define their own schemas and the Flow may generate or
-    compute values to these Actions and thus static, schema based validation cannot
-    determine if the Action parameter values generated during execution are correct.
+    """Perform local, JSONSchema based validation of a Flow definition.
+
+    This is validation on the basic structure of your Flow definition such as required
+    fields / properties for the various state types and the overall structure of the
+    Flow. This schema based validation *does not* do any validation of input values or
+    parameters passed to Actions as those Actions define their own schemas and the Flow
+    may generate or compute values to these Actions and thus static, schema based
+    validation cannot determine if the Action parameter values generated during
+    execution are correct.
 
     The input is the dictionary containing the flow definition.
 
     If the flow passes validation, no value is returned. If validation errors are found,
-    a FlowValidationError exception will be raised containing a string message describing
-    the error(s) encountered.
+    a FlowValidationError exception will be raised containing a string message
+    describing the error(s) encountered.
     """
     schema_path = Path(__file__).parent / "flows_schema.json"
     with schema_path.open() as sf:
@@ -273,7 +275,7 @@ class FlowsClient(BaseClient):
         :param flow_definition: A mapping corresponding to a Globus Flows
             definition.
 
-        :param title: A simple, human readable title for the deployed Flow
+        :param title: A simple, human-readable title for the deployed Flow
 
         :param subtitle: A longer, more verbose title for the deployed Flow
 
@@ -367,7 +369,7 @@ class FlowsClient(BaseClient):
         :param flow_definition: A mapping corresponding to a Globus Flows
             definition
 
-        :param title: A simple, human readable title for the deployed Flow
+        :param title: A simple, human-readable title for the deployed Flow
 
         :param subtitle: A longer, more verbose title for the deployed Flow
 
@@ -430,8 +432,7 @@ class FlowsClient(BaseClient):
         """
         Retrieve a deployed Flow's definition and metadata
 
-        :param flow_id: The UUID identifying the Flow for which to retrieve
-            details
+        :param flow_id: The UUID identifying the Flow for which to retrieve details
         """
 
         return self.get(f"/flows/{quote(flow_id)}", **kwargs)
@@ -449,14 +450,15 @@ class FlowsClient(BaseClient):
         """Display all deployed Flows for which you have the selected role(s)
 
         :param roles:
-            .. deprecated:: 0.12
-               Use ``role`` instead
+            ..  deprecated:: 0.12
+                Use ``role`` instead
 
             See description for ``role`` parameter. Providing multiple roles behaves as
             if only a single ``role`` value is provided and displays the equivalent of
             the most permissive role.
 
-        :param role: A role value specifying the minimum role-level permission which will
+        :param role:
+            A role value specifying the minimum role-level permission which will
             be displayed based on the follow precedence of role values:
 
             - flow_viewer
@@ -465,8 +467,8 @@ class FlowsClient(BaseClient):
             - flow_owner
 
             Thus, if, for example, ``flow_starter`` is specified, flows for which the
-            user has the ``flow_starter``, ``flow_administrator`` or ``flow_owner`` roles
-            will be returned.
+            user has the ``flow_starter``, ``flow_administrator`` or ``flow_owner``
+            roles will be returned.
 
         :param marker: A pagination_token indicating the page of results to
             return and how many entries to return. This is created by the Flows
@@ -569,7 +571,7 @@ class FlowsClient(BaseClient):
 
         :param flow_id: The UUID identifying the Flow to run
 
-        :param flow_scope:  The scope associated with the Flow ``flow_id``. If
+        :param flow_scope: The scope associated with the Flow ``flow_id``. If
             not provided, the SDK will attempt to perform an introspection on
             the Flow to determine its scope automatically
 
@@ -590,7 +592,7 @@ class FlowsClient(BaseClient):
 
         :param kwargs: Any additional kwargs passed into this method are passed
             onto the Globus BaseClient. If there exists an "authorizer" keyword
-            argument, that gets used to run the Flow operation. Otherwise the
+            argument, that gets used to run the Flow operation. Otherwise, the
             authorizer_callback defined for the FlowsClient will be used.
 
         :param dry_run: Set to ``True`` to test what will happen if the Flow is run
@@ -639,12 +641,11 @@ class FlowsClient(BaseClient):
             not provided, the SDK will attempt to perform an introspection on
             the Flow to determine its scope automatically
 
-        :param flow_action_id: The ID specifying the Action for which's status
-            we want to query
+        :param flow_action_id: The ID specifying which Action's status to query
 
         :param kwargs: Any additional kwargs passed into this method are passed
             onto the Globus BaseClient. If there exists an "authorizer" keyword
-            argument, that gets used to run the Flow operation. Otherwise the
+            argument, that gets used to run the Flow operation. Otherwise, the
             authorizer_callback defined for the FlowsClient will be used.
         """
         authorizer = self._get_authorizer_for_flow(flow_id, flow_scope, kwargs)
@@ -669,7 +670,7 @@ class FlowsClient(BaseClient):
 
         :param kwargs: Any additional kwargs passed into this method are passed
             onto the Globus BaseClient. If there exists an "authorizer" keyword
-            argument, that gets used to run the Flow operation. Otherwise the
+            argument, that gets used to run the Flow operation. Otherwise, the
             authorizer_callback defined for the FlowsClient will be used.
         """
         authorizer = self._get_authorizer_for_flow(flow_id, flow_scope, kwargs)
@@ -693,7 +694,7 @@ class FlowsClient(BaseClient):
 
         :param kwargs: Any additional kwargs passed into this method are passed
             onto the Globus BaseClient. If there exists an "authorizer" keyword
-            argument, that gets used to run the Flow operation. Otherwise the
+            argument, that gets used to run the Flow operation. Otherwise, the
             authorizer_callback defined for the FlowsClient will be used.
         """
         authorizer = self._get_authorizer_for_flow(flow_id, flow_scope, kwargs)
@@ -705,7 +706,7 @@ class FlowsClient(BaseClient):
         self, flow_id: str, flow_scope: Optional[str], flow_action_id: str, **kwargs
     ) -> GlobusHTTPResponse:
         """
-        Cancel the excution of an Action that was launched by a Flow
+        Cancel the execution of an Action that was launched by a Flow
 
         :param flow_id: The UUID identifying the Flow which launched the Action
 
@@ -717,7 +718,7 @@ class FlowsClient(BaseClient):
 
         :param kwargs: Any additional kwargs passed into this method are passed
             onto the Globus BaseClient. If there exists an "authorizer" keyword
-            argument, that gets used to run the Flow operation. Otherwise the
+            argument, that gets used to run the Flow operation. Otherwise, the
             authorizer_callback defined for the FlowsClient will be used.
         """
         authorizer = self._get_authorizer_for_flow(flow_id, flow_scope, kwargs)
@@ -757,8 +758,8 @@ class FlowsClient(BaseClient):
             if only a single ``role`` value is provided and displays the equivalent of
             the most permissive role.
 
-        :param role: A role value specifying the minimum role-level permission on the runs which will
-            be returned based on the follow precedence of role values:
+        :param role: A role value specifying the minimum role-level permission on the
+            runs which will be returned based on the follow precedence of role values:
 
             - run_monitor
             - run_manager
@@ -855,18 +856,19 @@ class FlowsClient(BaseClient):
         role: Optional[str] = None,
         **kwargs,
     ) -> GlobusHTTPResponse:
-        """List all Runs for a particular Flow. If no flow_id is provided, all runs for all
-        Flows will be returned.
+        """List all Runs for a particular Flow.
 
-        :param flow_id: The UUID identifying the Flow which launched the Run. If not
-            provided, all runs will be returned regardless of which Flow was used to start
-            the Run (equivalent to ``enumerate_runs``).
+        If no flow_id is provided, all runs for all Flows will be returned.
+
+        :param flow_id: The UUID identifying the Flow which launched the Run.
+            If not provided, all runs will be returned regardless of which Flow was
+            used to start the Run (equivalent to ``enumerate_runs``).
 
         :param flow_scope: The scope associated with the Flow ``flow_id``. If
             not provided, the SDK will attempt to perform an introspection on
             the Flow to determine its scope automatically
 
-        :param  statuses: The same as in ``enumerate_runs``.
+        :param statuses: The same as in ``enumerate_runs``.
 
         :param roles:
             ..  deprecated:: 0.12
@@ -874,19 +876,19 @@ class FlowsClient(BaseClient):
 
             The same as in ``enumerate_runs``.
 
-        :param  marker: The same as in ``enumerate_runs``.
+        :param marker: The same as in ``enumerate_runs``.
 
-        :param  per_page: The same as in ``enumerate_runs``.
+        :param per_page: The same as in ``enumerate_runs``.
 
-        :param  filters: The same as in ``enumerate_runs``.
+        :param filters: The same as in ``enumerate_runs``.
 
-        :param  orderings: The same as in ``enumerate_runs``.
+        :param orderings: The same as in ``enumerate_runs``.
 
-        :param  role: The same as in ``enumerate_runs``.
+        :param role: The same as in ``enumerate_runs``.
 
         :param kwargs: Any additional kwargs passed into this method are passed
             onto the Globus BaseClient. If there exists an "authorizer" keyword
-            argument, that gets used to run the Flow operation. Otherwise the
+            argument, that gets used to run the Flow operation. Otherwise, the
             authorizer_callback defined for the FlowsClient will be used.
 
         """
@@ -961,7 +963,7 @@ class FlowsClient(BaseClient):
 
         :param kwargs: Any additional kwargs passed into this method are passed
             onto the Globus BaseClient. If there exists an "authorizer" keyword
-            argument, that gets used to run the Flow operation. Otherwise the
+            argument, that gets used to run the Flow operation. Otherwise, the
             authorizer_callback defined for the FlowsClient will be used.
         """
         payload = {}
@@ -989,14 +991,13 @@ class FlowsClient(BaseClient):
         Retrieve an Action's execution log history for an Action that was launched by a
         specific Flow.
 
-        :param flow_id:  The UUID identifying the Flow which launched the Action
+        :param flow_id: The UUID identifying the Flow which launched the Action
 
         :param flow_scope: The scope associated with the Flow ``flow_id``. If
             not provided, the SDK will attempt to perform an introspection on
             the Flow to determine its scope automatically
 
-        :param flow_action_id: The ID specifying the Action for which's history
-            to query
+        :param flow_action_id: The ID specifying which Action's history to query
 
         :param limit: An integer specifying the maximum number of records for
             the Action's execution history to return.
@@ -1012,7 +1013,7 @@ class FlowsClient(BaseClient):
 
         :param kwargs: Any additional kwargs passed into this method are passed
             onto the Globus BaseClient. If there exists an "authorizer" keyword
-            argument, that gets used to run the Flow operation. Otherwise the
+            argument, that gets used to run the Flow operation. Otherwise, the
             authorizer_callback defined for the FlowsClient will be used.
         """
         authorizer = self._get_authorizer_for_flow(flow_id, flow_scope, kwargs)

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -9,6 +9,7 @@ from typing import (
     Iterable,
     Mapping,
     Optional,
+    Sequence,
     Set,
     Type,
     TypeVar,
@@ -935,9 +936,9 @@ class FlowsClient(BaseClient):
     def flow_action_update(
         self,
         action_id: str,
-        run_managers: Optional[Iterable[str]] = None,
-        run_monitors: Optional[Iterable[str]] = None,
-        tags: Optional[Iterable[str]] = None,
+        run_managers: Optional[Sequence[str]] = None,
+        run_monitors: Optional[Sequence[str]] = None,
+        tags: Optional[Sequence[str]] = None,
         label: Optional[str] = None,
         **kwargs,
     ) -> GlobusHTTPResponse:

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    List,
     Mapping,
     Optional,
     Sequence,
@@ -556,6 +557,7 @@ class FlowsClient(BaseClient):
         run_monitors: Optional[Iterable[str]] = None,
         dry_run: bool = False,
         label: Optional[str] = None,
+        tags: Optional[List[str]] = None,
         **kwargs,
     ) -> GlobusHTTPResponse:
         """
@@ -581,6 +583,8 @@ class FlowsClient(BaseClient):
             'urn:globus:auth:identity:'
 
         :param label: An optional label which can be used to identify this run
+
+        :param tags: Tags that will be associated with this Run.
 
         :param kwargs: Any additional kwargs passed into this method are passed
             onto the Globus BaseClient. If there exists an "authorizer" keyword
@@ -610,6 +614,7 @@ class FlowsClient(BaseClient):
                 monitor_by=run_monitors,
                 force_path=path,
                 label=label,
+                tags=tags,
                 **kwargs,
             )
         else:
@@ -618,6 +623,7 @@ class FlowsClient(BaseClient):
                 manage_by=run_managers,
                 monitor_by=run_monitors,
                 label=label,
+                tags=tags,
                 **kwargs,
             )
 

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -937,6 +937,8 @@ class FlowsClient(BaseClient):
         action_id: str,
         run_managers: Optional[Iterable[str]] = None,
         run_monitors: Optional[Iterable[str]] = None,
+        tags: Optional[Iterable[str]] = None,
+        label: Optional[str] = None,
         **kwargs,
     ) -> GlobusHTTPResponse:
         """
@@ -956,12 +958,23 @@ class FlowsClient(BaseClient):
             onto the Globus BaseClient. If there exists an "authorizer" keyword
             argument, that gets used to run the Flow operation. Otherwise, the
             authorizer_callback defined for the FlowsClient will be used.
+
+        :param tags:
+            A list of tags to apply to the Run.
+
+        :param label:
+            A label to apply to the Run.
         """
+
         payload = {}
         if run_managers is not None:
             payload["run_managers"] = run_managers
         if run_monitors is not None:
             payload["run_monitors"] = run_monitors
+        if tags is not None:
+            payload["tags"] = tags
+        if label is not None:
+            payload["label"] = label
 
         authorizer = self._get_authorizer_for_flow("", RUN_MANAGE_SCOPE, kwargs)
         with self.use_temporary_authorizer(authorizer):


### PR DESCRIPTION
These changes allow users to set tags and labels on runs (on the initial run and when updating), and to modify batches of runs.

# Changelog

Features
--------

-   [\[sc-13426\]](https://app.shortcut.com/globus/story/13426) Support setting tags when using the ``flow run`` subcommand.
-   Support batch updates of one or more Runs.
-   Support updating tags and labels using the ``flow run-update`` subcommand.
-   Support erasing the list of Run managers and Run monitors using the ``flow run-update`` subcommand.
    This can be done by specifying an empty string for the value of the ``--run-manager`` and ``--run-monitor`` options.
