### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         # we do not want a large number of windows and macos builds, so
         # enumerate them explicitly
         include:

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Run code linters
         # only lint on 3.9 for faster overall runs
         if: ${{ matrix.python-version == '3.9' }}
-        run: python -m tox -e mypy,flake8,isort
+        run: python -m tox -e mypy,flake8,isort,safety
       - name: Test documentation builds
         # make sure this does not fail, only on linux 3.9
         # because that's the build environment used (i.e. the one which really matters)

--- a/changelog.d/20220408_093928_kurtmckee_dependency_updates.rst
+++ b/changelog.d/20220408_093928_kurtmckee_dependency_updates.rst
@@ -1,5 +1,8 @@
 Development
 -----------
 
+-   Update typer to version 0.4.1.
 -   Update scriv to version 0.14.0.
     scriv is a development dependency.
+-   Temporarily remove typer-cli as a listed development dependency.
+    It is still needed when generating the CLI documentation.

--- a/changelog.d/20220408_093928_kurtmckee_dependency_updates.rst
+++ b/changelog.d/20220408_093928_kurtmckee_dependency_updates.rst
@@ -1,6 +1,8 @@
 Development
 -----------
 
+-   Update click to version 8.0.4.
+    This resolves a security issue.
 -   Update typer to version 0.4.1.
 -   Update scriv to version 0.14.0.
     scriv is a development dependency.

--- a/changelog.d/20220408_093928_kurtmckee_dependency_updates.rst
+++ b/changelog.d/20220408_093928_kurtmckee_dependency_updates.rst
@@ -1,0 +1,5 @@
+Development
+-----------
+
+-   Update scriv to version 0.14.0.
+    scriv is a development dependency.

--- a/changelog.d/20220408_093928_kurtmckee_dependency_updates.rst
+++ b/changelog.d/20220408_093928_kurtmckee_dependency_updates.rst
@@ -9,3 +9,4 @@ Development
 -   Temporarily remove typer-cli as a listed development dependency.
     It is still needed when generating the CLI documentation.
 -   Add safety as a test environment for local and CI testing.
+-   Test against Python 3.10 in CI.

--- a/changelog.d/20220408_093928_kurtmckee_dependency_updates.rst
+++ b/changelog.d/20220408_093928_kurtmckee_dependency_updates.rst
@@ -8,3 +8,4 @@ Development
     scriv is a development dependency.
 -   Temporarily remove typer-cli as a listed development dependency.
     It is still needed when generating the CLI documentation.
+-   Add safety as a test environment for local and CI testing.

--- a/changelog.d/README.rst
+++ b/changelog.d/README.rst
@@ -25,6 +25,4 @@ The fragments are collected and collated during the release process using this c
 
 ..  code-block:: shell
 
-    scriv collect --version $(poetry version -s)
-
-(`scriv issue #44 <https://github.com/nedbat/scriv/issues/44>`_ discusses how to read the version directly from ``pyproject.toml``.)
+    scriv collect

--- a/globus_automate_client/cli/rich_helpers.py
+++ b/globus_automate_client/cli/rich_helpers.py
@@ -432,15 +432,14 @@ class RequestRunner:
         self.render(Result(globus_resp))
 
     def run_and_render(self) -> Result:
+        result = self.run()
+
+        # It's assumed that no additional auth URL's will need to be written to STDOUT
+        # because of the successful call to `self.run()`, above.
         with live_content:
             while True:
-                # The .run() method may need access to STDOUT to display an auth URL.
-                # Pause the live content rendering to prevent STDOUT conflicts.
-                live_content.pause_live()
-                result = self.run()
-                live_content.resume_live()
                 self.render(result)
                 if not self.watch or self.run_once or result.completed:
-                    break
+                    return result
                 sleep(2)
-            return result
+                result = self.run()

--- a/globus_automate_client/cli/rich_rendering.py
+++ b/globus_automate_client/cli/rich_rendering.py
@@ -1,5 +1,3 @@
-import threading
-
 from rich.console import RenderGroup
 from rich.live import Live
 
@@ -17,36 +15,5 @@ class Content:
         return self.rg
 
 
-class PauseableLive(Live):
-    """
-    We need this hack to prevent the underlying Live thread from rewriting
-    stdout when we're attempting to get input from the user.
-    """
-
-    lock = threading.RLock()
-
-    def __enter__(self):
-        super().__enter__()
-        original_refresh = self._refresh_thread.live.refresh
-
-        def replacement_refresh():
-            with self.lock:
-                return original_refresh()
-
-        self._refresh_thread.live.refresh = replacement_refresh
-
-    def pause_live(self):
-        """Pause live rendering.
-
-        This is accomplished by acquiring the lock that the refresh thread depends on.
-        Although it's a re-entrant lock, only the main thread is able to release it.
-        """
-        self.lock.acquire()
-
-    def resume_live(self):
-        """Unpause live rendering."""
-        self.lock.release()
-
-
 cli_content = Content()
-live_content = PauseableLive(cli_content, refresh_per_second=20)
+live_content = Live(cli_content, refresh_per_second=20)

--- a/globus_automate_client/client_helpers.py
+++ b/globus_automate_client/client_helpers.py
@@ -4,7 +4,6 @@ from globus_sdk.authorizers import GlobusAuthorizer
 
 from globus_automate_client.action_client import ActionClient
 from globus_automate_client.cli.auth import CLIENT_ID, get_cli_authorizer
-from globus_automate_client.cli.rich_rendering import live_content
 from globus_automate_client.flows_client import (
     MANAGE_FLOWS_SCOPE,
     PROD_FLOWS_BASE_URL,
@@ -57,11 +56,9 @@ def create_action_client(
         >>> resp = ac.run({"echo_string": "Hello from SDK"})
         >>> assert resp.data["status"] == "SUCCEEDED"
     """
-    live_content.pause_live()
     authorizer = get_cli_authorizer(
         action_url=action_url, action_scope=action_scope, client_id=client_id
     )
-    live_content.resume_live()
     return ActionClient.new_client(action_url=action_url, authorizer=authorizer)
 
 
@@ -70,9 +67,7 @@ def cli_authorizer_callback(**kwargs):
     flow_scope = kwargs["flow_scope"]
     client_id = kwargs["client_id"]
 
-    live_content.pause_live()
     authorizer = get_cli_authorizer(flow_url, flow_scope, client_id)
-    live_content.resume_live()
     return authorizer
 
 

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -221,6 +221,8 @@ class FlowsClient(BaseClient):
         get_authorizer_callback: AuthorizerCallbackType,
         **kwargs,
     ) -> None:
+        if "base_url" not in kwargs:
+            kwargs["base_url"] = _get_flows_base_url_for_environment()
         super().__init__(**kwargs)
         self.client_id = client_id
         self.get_authorizer_callback = get_authorizer_callback

--- a/poetry.lock
+++ b/poetry.lock
@@ -204,11 +204,15 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "7.1.2"
+version = "8.0.4"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "click-log"
@@ -1780,8 +1784,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.7-py3-none-any.whl", hash = "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"},
 ]
 click = [
-    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
-    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
+    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
 ]
 click-log = [
     {file = "click-log-0.3.2.tar.gz", hash = "sha256:16fd1ca3fc6b16c98cea63acf1ab474ea8e676849dc669d86afafb0ed7003124"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1241,7 +1241,7 @@ docutils = ">=0.7"
 
 [[package]]
 name = "scriv"
-version = "0.12.0"
+version = "0.14.0"
 description = "Scriv changelog management tool"
 category = "dev"
 optional = false
@@ -1664,7 +1664,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "43607feb756b228dfa4c34794be540e5c91e1e7d82e0545129601c75d8c84817"
+content-hash = "4ea47e96726263361074e59660a497463de76693d1d93392b9a841ca2d0ab80a"
 
 [metadata.files]
 alabaster = [
@@ -2332,8 +2332,8 @@ rstcheck = [
     {file = "rstcheck-3.3.1.tar.gz", hash = "sha256:92c4f79256a54270e0402ba16a2f92d0b3c15c8f4410cb9c57127067c215741f"},
 ]
 scriv = [
-    {file = "scriv-0.12.0-py2.py3-none-any.whl", hash = "sha256:62d9d91466a6c629fb72964290906eba1331d4d53c219e95c57f050b62d30ca5"},
-    {file = "scriv-0.12.0.tar.gz", hash = "sha256:0c1b055afea1773d50f13728f301dd4aa0d35e68be4e2f1e7373b51ec225de0a"},
+    {file = "scriv-0.14.0-py2.py3-none-any.whl", hash = "sha256:8236f8019f6b3ca407d1ce0992751e5b2498545135e32fa3e038eb12fcc2ab71"},
+    {file = "scriv-0.14.0.tar.gz", hash = "sha256:8c2523762a69a08c9cc44a99e747d4a0921b493f7c84c4b0d7c370a7b2044a61"},
 ]
 send2trash = [
     {file = "Send2Trash-1.8.0-py3-none-any.whl", hash = "sha256:f20eaadfdb517eaca5ce077640cb261c7d2698385a6a0f072a4a5447fd49fa08"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1534,35 +1534,22 @@ python-versions = "*"
 
 [[package]]
 name = "typer"
-version = "0.3.2"
+version = "0.4.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-click = ">=7.1.1,<7.2.0"
+click = ">=7.1.1,<9.0.0"
 colorama = {version = ">=0.4.3,<0.5.0", optional = true, markers = "extra == \"all\""}
 shellingham = {version = ">=1.3.0,<2.0.0", optional = true, markers = "extra == \"all\""}
 
 [package.extras]
-test = ["pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.782)", "black (>=19.10b0,<20.0b0)", "isort (>=5.0.6,<6.0.0)", "shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)"]
 all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)"]
 dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)"]
-doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.4.0,<6.0.0)", "markdown-include (>=0.5.1,<0.6.0)"]
-
-[[package]]
-name = "typer-cli"
-version = "0.0.12"
-description = "Run Typer scripts with completion, without having to create a package, using Typer CLI."
-category = "dev"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[package.dependencies]
-colorama = ">=0.4.3,<0.5.0"
-shellingham = ">=1.3.2,<2.0.0"
-typer = ">=0.3.0,<0.4.0"
+doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mdx-include (>=1.4.1,<2.0.0)"]
+test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=22.3.0,<23.0.0)", "isort (>=5.0.6,<6.0.0)"]
 
 [[package]]
 name = "types-pyyaml"
@@ -1664,7 +1651,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "4ea47e96726263361074e59660a497463de76693d1d93392b9a841ca2d0ab80a"
+content-hash = "0220fb725e199dc292901732667fddbfe1ea931402abaf45079eeea641509f85"
 
 [metadata.files]
 alabaster = [
@@ -2494,12 +2481,8 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typer = [
-    {file = "typer-0.3.2-py3-none-any.whl", hash = "sha256:ba58b920ce851b12a2d790143009fa00ac1d05b3ff3257061ff69dbdfc3d161b"},
-    {file = "typer-0.3.2.tar.gz", hash = "sha256:5455d750122cff96745b0dec87368f56d023725a7ebc9d2e54dd23dc86816303"},
-]
-typer-cli = [
-    {file = "typer-cli-0.0.12.tar.gz", hash = "sha256:d2c4a7a5c0326c20fb0970eed3c2173f76ba6b8b33d9bbece3a3dd91d673f096"},
-    {file = "typer_cli-0.0.12-py3-none-any.whl", hash = "sha256:f9b810d4fbdb750b28ceaa5fd8f737db596570418ae092e6d54a64d378e843ca"},
+    {file = "typer-0.4.1-py3-none-any.whl", hash = "sha256:e8467f0ebac0c81366c2168d6ad9f888efdfb6d4e1d3d5b4a004f46fa444b5c3"},
+    {file = "typer-0.4.1.tar.gz", hash = "sha256:5646aef0d936b2c761a10393f0384ee6b5c7fe0bb3e5cd710b17134ca1d99cff"},
 ]
 types-pyyaml = [
     {file = "types-PyYAML-5.4.12.tar.gz", hash = "sha256:3f4daa754357491625ae8c3a39c9e1b0d7cd5632bc4e1c35e7a7f75a64aa124b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ python = "^3.6.2"
 globus-sdk = "^3.1"
 graphviz = "^0.12"
 importlib-metadata = {version = "^4.8.1", python = "<3.8"}
-typer = {extras = ["all"], version = "^0.3.0"}
+typer = {extras = ["all"], version = "^0.4.1"}
 jsonschema = "^3.2.0"
 PyYAML = "^5.3.1"
 rich = "^9.12.2"
@@ -49,7 +49,12 @@ sphinx = "^3.2.1"
 rstcheck = "^3.3.1"
 furo = "^2021.4.11-beta.34"
 sphinx-copybutton = "^0.3.1"
-typer-cli = "^0.0.12"
+# ----
+# typer-cli is temporarily disabled due to its dependencies.
+# When it is compatible with our typer dependency, update the dev dependency here
+# and modify the Makefile's "docs" target to remove the pip install/uninstall calls.
+# typer-cli = "^0.0.12"
+# ----
 pypandoc = "^1.5"
 importmagic = "^0.1.7"
 epc = "^0.0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ black = {extras = ["jupyter"], version = "^21.12b0"}
 mypy = "^0.910"
 types-PyYAML = "^5.4.6"
 types-requests = "^2.25.6"
-scriv = {extras = ["toml"], version = "^0.12.0"}
+scriv = {extras = ["toml"], version = "^0.14.0"}
 tox = "^3.24.4"
 pre-commit = "^2.15.0"
 responses = "^0.14.0"
@@ -82,6 +82,7 @@ ignore_missing_imports = true
 
 [tool.scriv]
 categories = ["Features", "Bugfixes", "Documentation"]
+version = "literal: pyproject.toml: tool.poetry.version"
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_action_client.py
+++ b/tests/test_action_client.py
@@ -26,7 +26,7 @@ def test_action_scope(ac, mocked_responses, data, expected):
 
     mocked_responses.add(
         method=responses.GET,
-        url="https://actions.api.globus.org/",
+        url=action_client.PRODUCTION_ACTIONS_BASE_URL,
         json=data,
     )
     assert ac._action_scope is None
@@ -48,7 +48,7 @@ def test_trivial_methods(ac, mocked_responses, name, method):
     """Validate the URL used with trivial requests."""
 
     action_id = "bogus"
-    url = f"https://actions.api.globus.org/{action_id}/{name}"
+    url = f"{action_client.PRODUCTION_ACTIONS_BASE_URL}/{action_id}/{name}"
     mocked_responses.add(method=method, url=url)
     getattr(ac, name)(action_id)  # Dynamically get and call the method by name
     assert mocked_responses.calls[0].request.url == url
@@ -58,7 +58,7 @@ def test_trivial_methods(ac, mocked_responses, name, method):
 def test_run_with_request_id(ac, mocked_responses, monkeypatch, request_id):
     """Validate that run() uses a specified request ID or generates a new one."""
 
-    url = "https://actions.api.globus.org/run"
+    url = f"{action_client.PRODUCTION_ACTIONS_BASE_URL}/run"
     mocked_responses.add(method="POST", url=url)
     monkeypatch.setattr(uuid, "uuid4", lambda: "system")
     ac.run(body={}, request_id=request_id)
@@ -72,7 +72,7 @@ def test_run_with_request_id(ac, mocked_responses, monkeypatch, request_id):
 def test_run_with_force_path(ac, mocked_responses, force_path):
     """Validate that run() uses *force_path*, if specified."""
 
-    url = f"https://actions.api.globus.org{force_path or '/run'}"
+    url = f"{action_client.PRODUCTION_ACTIONS_BASE_URL}{force_path or '/run'}"
     mocked_responses.add(method="POST", url=url)
     ac.run(body={}, force_path=force_path)
     assert mocked_responses.calls[0].request.url == url
@@ -94,7 +94,9 @@ def test_run_with_force_path(ac, mocked_responses, force_path):
 def test_run_with_managers_and_monitors(ac, mocked_responses, kwargs, expected):
     """Validate that run() uses managers and monitors, including aliases."""
 
-    mocked_responses.add(method="POST", url="https://actions.api.globus.org/run")
+    mocked_responses.add(
+        method="POST", url=f"{action_client.PRODUCTION_ACTIONS_BASE_URL}/run"
+    )
     ac.run(body={}, **kwargs)
     data = json.loads(mocked_responses.calls[0].request.body.decode("utf8"))
     for key in ("monitor_by", "manage_by"):
@@ -109,7 +111,7 @@ def test_log_reverse_order(ac, mocked_responses, reverse_order, expected):
     """Validate the *reverse_order* parameter is managed correctly."""
 
     action_id = "bogus"
-    url = f"https://actions.api.globus.org/{action_id}/log"
+    url = f"{action_client.PRODUCTION_ACTIONS_BASE_URL}/{action_id}/log"
     mocked_responses.add(method="GET", url=url, json={})
     ac.log(action_id, reverse_order=reverse_order)
     query: str = urllib.parse.urlparse(mocked_responses.calls[0].request.url).query
@@ -130,7 +132,7 @@ def test_log_pagination(ac, mocked_responses, marker, per_page, expected):
     """Validate the *marker* and *per_page* parameters interact correctly."""
 
     action_id = "bogus"
-    url = f"https://actions.api.globus.org/{action_id}/log"
+    url = f"{action_client.PRODUCTION_ACTIONS_BASE_URL}/{action_id}/log"
     mocked_responses.add(method="GET", url=url, json={})
     ac.log(action_id, marker=marker, per_page=per_page)
     query: str = urllib.parse.urlparse(mocked_responses.calls[0].request.url).query

--- a/tests/test_flows_client.py
+++ b/tests/test_flows_client.py
@@ -148,8 +148,8 @@ def test_validate_input_schema_multiple_failures():
 @pytest.mark.parametrize(
     "value, expected",
     (
-        (None, "https://flows.globus.org"),
-        ("prod", "https://flows.globus.org"),
+        (None, flows_client.PROD_FLOWS_BASE_URL),
+        ("prod", flows_client.PROD_FLOWS_BASE_URL),
         ("bogus", ValueError),
     ),
 )
@@ -167,7 +167,7 @@ def test_get_flows_base_url_for_environment_known(monkeypatch, value, expected):
 def test_deploy_flow_data_construction(fc, mocked_responses):
     """Verify the flow JSON data is constructed correctly."""
 
-    mocked_responses.add("POST", "https://flows.api.globus.org/flows")
+    mocked_responses.add("POST", f"{flows_client.PROD_FLOWS_BASE_URL}/flows")
     expected: Dict[str, Union[str, Dict[str, Any]]] = {
         "definition": VALID_FLOW_DEFINITION,
         "input_schema": {"Comment": "flow-input-schema"},
@@ -207,7 +207,7 @@ def test_deploy_flow_only_exclude_input_schema_if_none(
 ):
     """Verify the *input_schema* is not excluded even if it's false-y."""
 
-    mocked_responses.add("POST", "https://flows.api.globus.org/flows")
+    mocked_responses.add("POST", f"{flows_client.PROD_FLOWS_BASE_URL}/flows")
     fc.deploy_flow(
         # Included arguments
         flow_definition=VALID_FLOW_DEFINITION,
@@ -231,7 +231,7 @@ def test_deploy_flow_only_exclude_input_schema_if_none(
 def test_deploy_flow_dry_run(fc, mocked_responses, dry_run, path):
     """Verify the *dry_run* parameter affects the URL path."""
 
-    url = f"https://flows.api.globus.org/{path}"
+    url = f"{flows_client.PROD_FLOWS_BASE_URL}/{path}"
     mocked_responses.add("POST", url)
     fc.deploy_flow(
         flow_definition=VALID_FLOW_DEFINITION,
@@ -245,7 +245,7 @@ def test_deploy_flow_dry_run(fc, mocked_responses, dry_run, path):
 def test_deploy_flow_aliases(fc, mocked_responses):
     """Verify that viewer/starter/admin aliases are still supported."""
 
-    mocked_responses.add("POST", "https://flows.api.globus.org/flows")
+    mocked_responses.add("POST", f"{flows_client.PROD_FLOWS_BASE_URL}/flows")
     fc.deploy_flow(
         # Flow viewers and aliases
         flow_viewers=["v1", "v2"],
@@ -302,7 +302,7 @@ def test_invalid_input_schema_failure(fc, method):
 def test_update_flow_data_construction(fc, mocked_responses):
     """Verify the flow JSON data is constructed correctly."""
 
-    mocked_responses.add("PUT", "https://flows.api.globus.org/flows/bogus")
+    mocked_responses.add("PUT", f"{flows_client.PROD_FLOWS_BASE_URL}/flows/bogus")
     expected: Dict[str, Union[str, Dict[str, Any]]] = {
         "definition": VALID_FLOW_DEFINITION,
         "input_schema": {"Comment": "flow-input-schema"},
@@ -342,7 +342,7 @@ def test_update_flow_exclude_most_false_values(
 ):
     """Verify the *input_schema* is not excluded even if it's false-y."""
 
-    mocked_responses.add("PUT", "https://flows.api.globus.org/flows/bogus")
+    mocked_responses.add("PUT", f"{flows_client.PROD_FLOWS_BASE_URL}/flows/bogus")
     fc.update_flow(
         # *input_schema* is being tested for inclusion/exclusion.
         input_schema=input_schema,
@@ -365,7 +365,7 @@ def test_update_flow_exclude_most_false_values(
 def test_update_flow_aliases(fc, mocked_responses):
     """Verify that viewer/starter/admin aliases are still supported."""
 
-    mocked_responses.add("PUT", "https://flows.api.globus.org/flows/bogus")
+    mocked_responses.add("PUT", f"{flows_client.PROD_FLOWS_BASE_URL}/flows/bogus")
     fc.update_flow(
         # Flow viewers and aliases
         flow_viewers=["v1", "v2"],
@@ -395,7 +395,7 @@ def test_update_flow_aliases(fc, mocked_responses):
 def test_get_flow(fc, mocked_responses):
     """Verify the URL that is used to get a flow definition."""
 
-    url = "https://flows.api.globus.org/flows/bogus"
+    url = f"{flows_client.PROD_FLOWS_BASE_URL}/flows/bogus"
     mocked_responses.add("GET", url)
     fc.get_flow("bogus")
     assert mocked_responses.calls[0].request.url == url
@@ -420,7 +420,7 @@ def test_list_flows_role_precedence(
 ):
     """Verify the *role* and *roles* precedence rules."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/flows")
     fc.list_flows(role=role, roles=roles)
     query: str = urllib.parse.urlparse(mocked_responses.calls[0].request.url).query
     data = dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
@@ -451,7 +451,7 @@ def test_list_flows_pagination_parameters(
 ):
     """Verify *marker* and *per_page* precedence rules."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/flows")
     fc.list_flows(marker=marker, per_page=per_page)
     query: str = urllib.parse.urlparse(mocked_responses.calls[0].request.url).query
     data = dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
@@ -466,7 +466,7 @@ def test_list_flows_pagination_parameters(
 def test_list_flows_filters(fc, mocked_responses):
     """Verify that filters are applied to the query parameters."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/flows")
     fc.list_flows(role="role", filters={"1": "2", "filter_role": "bogus"})
     query: str = urllib.parse.urlparse(mocked_responses.calls[0].request.url).query
     data = dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
@@ -477,7 +477,7 @@ def test_list_flows_filters(fc, mocked_responses):
 def test_list_flows_orderings(fc, mocked_responses):
     """Verify that orderings are serialized as expected."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/flows")
     fc.list_flows(orderings={"shape": "asc", "color": "DESC", "bogus": "undefined"})
     query: str = urllib.parse.urlparse(mocked_responses.calls[0].request.url).query
     data = dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
@@ -491,7 +491,7 @@ def test_list_flows_orderings(fc, mocked_responses):
 def test_delete_flow(fc, mocked_responses):
     """Verify the URL used when deleting a flow."""
 
-    url = "https://flows.api.globus.org/flows/bogus"
+    url = f"{flows_client.PROD_FLOWS_BASE_URL}/flows/bogus"
     mocked_responses.add("DELETE", url)
     fc.delete_flow("bogus")
     assert mocked_responses.calls[0].request.url == url
@@ -505,7 +505,7 @@ def test_scope_for_flow(fc, mocked_responses):
 
     mocked_responses.add(
         method="GET",
-        url="https://flows.api.globus.org/flows/bogus-id",
+        url=f"{flows_client.PROD_FLOWS_BASE_URL}/flows/bogus-id",
         json={"globus_auth_scope": "bogus-scope"},
     )
     assert fc.scope_for_flow("bogus-id") == "bogus-scope"
@@ -539,7 +539,7 @@ def test_get_authorizer_for_flow_scope_lookup(fc, monkeypatch, flow_scope, expec
 def test_run_flow_dry_run(fc, mocked_responses, dry_run, expected):
     """Verify the *dry_run* parameter affects the URL path."""
 
-    url = f"https://flows.api.globus.org/flows/bogus-id/{expected}"
+    url = f"{flows_client.PROD_FLOWS_BASE_URL}/flows/bogus-id/{expected}"
     mocked_responses.add("POST", url)
     fc.run_flow(
         # *dry_run* is being tested.
@@ -627,7 +627,7 @@ def test_run_flow_aliases(
 
     mocked_responses.add(
         method="POST",
-        url="https://flows.api.globus.org/flows/bogus-id/run",
+        url=f"{flows_client.PROD_FLOWS_BASE_URL}/flows/bogus-id/run",
         json={},
     )
     fc.run_flow(
@@ -671,7 +671,7 @@ def test_enumerate_runs_role_precedence(
     """Verify the *role* and *roles* precedence rules."""
 
     monkeypatch.setattr(fc, "get_authorizer_callback", lambda **x: fc.authorizer)
-    mocked_responses.add("GET", "https://flows.api.globus.org/runs")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/runs")
     fc.enumerate_runs(role=role, roles=roles)
     query: str = urllib.parse.urlparse(mocked_responses.calls[0].request.url).query
     data = dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
@@ -703,7 +703,7 @@ def test_enumerate_runs_pagination_parameters(
     """Verify *marker* and *per_page* precedence rules."""
 
     monkeypatch.setattr(fc, "get_authorizer_callback", lambda **x: fc.authorizer)
-    mocked_responses.add("GET", "https://flows.api.globus.org/runs")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/runs")
     fc.enumerate_runs(marker=marker, per_page=per_page)
     query: str = urllib.parse.urlparse(mocked_responses.calls[0].request.url).query
     data = dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
@@ -719,7 +719,7 @@ def test_enumerate_runs_filters(fc, mocked_responses, monkeypatch):
     """Verify that filters are applied to the query parameters."""
 
     monkeypatch.setattr(fc, "get_authorizer_callback", lambda **x: fc.authorizer)
-    mocked_responses.add("GET", "https://flows.api.globus.org/runs")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/runs")
     fc.enumerate_runs(role="role", filters={"1": "2", "filter_role": "bogus"})
     query: str = urllib.parse.urlparse(mocked_responses.calls[0].request.url).query
     data = dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
@@ -731,7 +731,7 @@ def test_enumerate_runs_orderings(fc, mocked_responses, monkeypatch):
     """Verify that orderings are serialized as expected."""
 
     monkeypatch.setattr(fc, "get_authorizer_callback", lambda **x: fc.authorizer)
-    mocked_responses.add("GET", "https://flows.api.globus.org/runs")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/runs")
     fc.enumerate_runs(orderings={"shape": "asc", "color": "DESC", "bogus": "bad"})
     query: str = urllib.parse.urlparse(mocked_responses.calls[0].request.url).query
     data = dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
@@ -746,7 +746,7 @@ def test_enumerate_runs_statuses(fc, mocked_responses, monkeypatch):
     """Verify that orderings are serialized as expected."""
 
     monkeypatch.setattr(fc, "get_authorizer_callback", lambda **x: fc.authorizer)
-    mocked_responses.add("GET", "https://flows.api.globus.org/runs")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/runs")
     fc.enumerate_runs(statuses=("SUCCEEDED", "FAILED"))
     query: str = urllib.parse.urlparse(mocked_responses.calls[0].request.url).query
     data = dict(urllib.parse.parse_qsl(query, keep_blank_values=True))
@@ -772,7 +772,7 @@ def test_list_flow_runs_role_precedence(
 ):
     """Verify the *role* and *roles* precedence rules."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/runs")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/flows/-/runs")
     fc.list_flow_runs(
         "-",
         role=role,
@@ -808,7 +808,7 @@ def test_list_flow_runs_pagination_parameters(
 ):
     """Verify *marker* and *per_page* precedence rules."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/runs")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/flows/-/runs")
     fc.list_flow_runs(
         "-",
         marker=marker,
@@ -828,7 +828,7 @@ def test_list_flow_runs_pagination_parameters(
 def test_list_flow_runs_filters(fc, mocked_responses):
     """Verify that filters are applied to the query parameters."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/runs")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/flows/-/runs")
     fc.list_flow_runs(
         "-",
         role="role",
@@ -844,7 +844,7 @@ def test_list_flow_runs_filters(fc, mocked_responses):
 def test_list_flow_runs_orderings(fc, mocked_responses):
     """Verify that orderings are serialized as expected."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/runs")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/flows/-/runs")
     fc.list_flow_runs(
         "-",
         orderings={"shape": "asc", "color": "DESC", "bogus": "bad"},
@@ -862,7 +862,7 @@ def test_list_flow_runs_orderings(fc, mocked_responses):
 def test_list_flow_runs_statuses(fc, mocked_responses):
     """Verify that orderings are serialized as expected."""
 
-    mocked_responses.add("GET", "https://flows.api.globus.org/flows/-/runs")
+    mocked_responses.add("GET", f"{flows_client.PROD_FLOWS_BASE_URL}/flows/-/runs")
     fc.list_flow_runs(
         "-",
         statuses=("SUCCEEDED", "FAILED"),
@@ -916,7 +916,7 @@ def test_flow_action_update_managers_and_monitors(
 ):
     """Verify that managers and monitors are unconditionally included."""
 
-    mocked_responses.add("PUT", "https://flows.api.globus.org/runs/bogus-id")
+    mocked_responses.add("PUT", f"{flows_client.PROD_FLOWS_BASE_URL}/runs/bogus-id")
     fc.flow_action_update(
         # These arguments are being tested.
         run_managers=run_managers,

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     flake8
     isort
     mypy
+    safety
 skip_missing_interpreters = True
 isolated_build = True
 
@@ -78,3 +79,9 @@ deps =
     types-requests
 commands =
     {envpython} -m mypy globus_automate_client tests docs
+
+[testenv:safety]
+deps =
+    safety
+commands =
+    {envpython} -m safety check


### PR DESCRIPTION
This introduces several dependency updates, [one of which (click)](https://github.com/pallets/click/issues/1752) contains a security fix. There are other items addressed, see the changelog below for details.

Note: Upgrading typer currently prevents us from keeping typer-cli as a development dependency. There is a temporary hack in the Makefile to mitigate this. The issue is being tracked in tiangolo/typer-cli#50.


# Changelog

Development
-----------

-   Update click to version 8.0.4.
    This resolves a security issue.
-   Update typer to version 0.4.1.
-   Update scriv to version 0.14.0.
    scriv is a development dependency.
-   Temporarily remove typer-cli as a listed development dependency.
    It is still needed when generating the CLI documentation.
-   Add safety as a test environment for local and CI testing.
-   Test against Python 3.10 in CI.
