### PR TITLE
Release/0.15.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,19 @@ Unreleased changes are documented in files in the `changelog.d`_ directory.
 
 ..  scriv-insert-here
 
+.. _changelog-0.15.1:
+
+0.15.1 — 2022-05-09
+===================
+
+Bugfixes
+--------
+
+-   Fix a missing dependency when running on Python 3.10.
+
+    This was fixed by adding typing-extensions as an explicit dependency.
+    Note that pip may need to be upgraded due to changes in its dependency resolver.
+
 .. _changelog-0.15.0.post1:
 
 0.15.0.post1 — 2022-05-09

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,13 @@ Automate suite of services.
 Basic Usage
 -----------
 
-Install with ``pip install globus-automate-client``
+Install with these commands:
+
+..  code-block:: shell
+
+    python -m pip install --upgrade pip setuptools wheel
+    python -m pip install globus-automate-client
+
 
 You can then import Globus Automate client classes and other helpers from
 ``globus_automate_client``. For example:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1654,7 +1654,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.3"
-content-hash = "6c18074d1d2ed4693b8dcde8e142b3c4137f3bdef876e6788b2df139bc05568a"
+content-hash = "e9c433bbd445e3665bb947e72a5e97abc022c7fc2a2ff0e94c7675b72691ce1f"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ jsonschema = "^3.2.0"
 PyYAML = "^5.3.1"
 rich = "^12.3.0"
 arrow = "^1.1.1"
+typing-extensions = "^4.1.1"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "globus-automate-client"
-version = "0.15.0.post1"
+version = "0.15.1"
 description = "Client for the Globus Flows service"
 authors = [
     "Jake Lewis <jake@globus.org>",


### PR DESCRIPTION
0.15.1 — 2022-05-09
===================

Bugfixes
--------

-   Fix a missing dependency when running on Python 3.10.

    This was fixed by adding typing-extensions as an explicit dependency.
    Note that pip may need to be upgraded due to changes in its dependency resolver.

