### PR TITLE
Update pyjwt to 2.4.0

### DIFF
--- a/changelog.d/20220613_121945_kurtmckee_update_pyjwt.rst
+++ b/changelog.d/20220613_121945_kurtmckee_update_pyjwt.rst
@@ -1,0 +1,5 @@
+Bugfixes
+--------
+
+-   Update pyjwt to version 2.4.0 to address
+    `CVE-2022-29217 <https://nvd.nist.gov/vuln/detail/CVE-2022-29217>`_.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1030,7 +1030,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "pyjwt"
-version = "2.3.0"
+version = "2.4.0"
 description = "JSON Web Token implementation in Python"
 category = "main"
 optional = false
@@ -2152,8 +2152,8 @@ pygments = [
     {file = "Pygments-2.10.0.tar.gz", hash = "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"},
 ]
 pyjwt = [
-    {file = "PyJWT-2.3.0-py3-none-any.whl", hash = "sha256:e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f"},
-    {file = "PyJWT-2.3.0.tar.gz", hash = "sha256:b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41"},
+    {file = "PyJWT-2.4.0-py3-none-any.whl", hash = "sha256:72d1d253f32dbd4f5c88eaf1fdc62f3a19f676ccbadb9dbc5d07e951b2b26daf"},
+    {file = "PyJWT-2.4.0.tar.gz", hash = "sha256:d42908208c699b3b973cbeb01a969ba6a96c821eefb1c5bfe4c390c01d67abba"},
 ]
 pypandoc = [
     {file = "pypandoc-1.6.4-py3-none-win_amd64.whl", hash = "sha256:080903342d8cca6d953835c103b0f280a6cb66a6a20102692143a138b046c44f"},


### PR DESCRIPTION
Bugfixes
--------

-   Update pyjwt to version 2.4.0 to address [CVE-2022-29217](https://nvd.nist.gov/vuln/detail/CVE-2022-29217).
