### PR TITLE
Standardize options

### DIFF
--- a/changelog.d/20220613_175005_kurtmckee_standardize_options_sc_13892.rst
+++ b/changelog.d/20220613_175005_kurtmckee_standardize_options_sc_13892.rst
@@ -1,0 +1,29 @@
+Bugfixes
+--------
+
+-   `[sc-13892] <https://app.shortcut.com/globus/story/13892>`_
+    Standardize flow viewer, starter, and administrator arguments -- and their aliases -- throughout the CLI and API.
+
+    Although this change fixes bugs that prevented documented CLI options from working,
+    it also introduces breaking changes:
+
+    *   ``--flow-viewer``, ``--flow-starter``, and ``--flow-administrator`` are the canonical CLI options.
+    *   The CLI option aliases will continue to work, but the alias behavior has changed:
+
+        *   If an alias is used, a warning is written to STDERR.
+        *   If the canonical option name is combined with one of its aliases,
+            an error will be written to STDERR and the Automate client will exit.
+            The exit code will be 1.
+        *   If more than one of the acceptable aliases is used (like ``--starter`` and ``--runnable-by``),
+            an error will be written to STDERR and the Automate client will exit.
+            The exit code will be 1.
+
+    In addition, there are breaking changes in the API:
+
+    *   ``flow_viewers``, ``flow_starters``, and ``flow_administrators`` are the canonical API argument names.
+    *   The API argument aliases will continue to work, but the alias behavior has changed:
+
+        *   If an alias is used, a Python warning will be issued.
+            Applications can control the warning behavior using Python's ``warnings`` module.
+        *   If the canonical option name is combined with one of its aliases, a ``ValueError`` will be raised.
+        *   If more than one of the acceptable aliases is used (like ``starters`` and ``runnable_by``), a ``ValueError`` will be raised.

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -349,12 +349,6 @@ def flow_update(
     administered_by: List[str] = typer.Option(
         None, callback=principal_validator, hidden=True
     ),
-    assume_ownership: bool = typer.Option(
-        False,
-        "--assume-ownership",
-        help="Assume the ownership of the Flow. This can only be performed by user's "
-        "in the flow_administrators role.",
-    ),
     subscription_id: Optional[str] = typer.Option(
         None,
         help="The Globus Subscription which will be used to make this flow managed.",

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -93,8 +93,9 @@ def flow_deploy(
     definition: str = typer.Option(
         ...,
         help=(
-            "JSON or YAML representation of the Flow to deploy. May be provided as a filename "
-            "or a raw string representing a JSON object or YAML definition."
+            "JSON or YAML representation of the Flow to deploy. "
+            "May be provided as a filename or a raw string "
+            "representing a JSON object or YAML definition."
         ),
         prompt=True,
         callback=input_validator,
@@ -150,8 +151,8 @@ def flow_deploy(
             "A principal which may run an instance of the deployed Flow. "
             + _principal_description
             + "The special value of "
-            "'all_authenticated_users' may be used to indicate that any authenticated user "
-            "can invoke this flow. [repeatable]"
+            "'all_authenticated_users' may be used to indicate that "
+            "any authenticated user can invoke this flow. [repeatable]"
         ),
         callback=custom_principal_validator({"all_authenticated_users"}),
     ),
@@ -186,7 +187,7 @@ def flow_deploy(
     ),
     subscription_id: Optional[str] = typer.Option(
         None,
-        help="The Id of the Globus Subscription which will be used to make this flow managed.",
+        help="The ID of the Globus Subscription which will manage the Flow.",
     ),
     validate: bool = typer.Option(
         True,
@@ -275,8 +276,8 @@ def flow_update(
     definition: str = typer.Option(
         None,
         help=(
-            "JSON or YAML representation of the Flow to update. May be provided as a filename "
-            "or a raw string."
+            "JSON or YAML representation of the Flow to update. "
+            "May be provided as a filename or a raw string."
         ),
         callback=input_validator,
     ),
@@ -360,7 +361,7 @@ def flow_update(
     ),
     validate: bool = typer.Option(
         True,
-        help=("(EXPERIMENTAL) Perform rudimentary validation of the flow definition."),
+        help="(EXPERIMENTAL) Perform rudimentary validation of the flow definition.",
         case_sensitive=False,
         show_default=True,
     ),
@@ -420,8 +421,8 @@ def flow_lint(
     definition: str = typer.Option(
         ...,
         help=(
-            "JSON or YAML representation of the Flow to deploy. May be provided as a filename "
-            "or a raw string."
+            "JSON or YAML representation of the Flow to deploy. "
+            "May be provided as a filename or a raw string."
         ),
         prompt=True,
         callback=input_validator,
@@ -469,7 +470,9 @@ def flow_list(
         None,
         "--per-page",
         "-p",
-        help="The page size to return. Only valid when used without providing a marker.",
+        help=(
+            "The page size to return. Only valid when used without providing a marker."
+        ),
         min=1,
         max=50,
     ),
@@ -541,8 +544,9 @@ def flow_display(
     flow_definition: str = typer.Option(
         "",
         help=(
-            "JSON or YAML representation of the Flow to display. May be provided as a filename "
-            "or a raw string representing a JSON object or YAML definition."
+            "JSON or YAML representation of the Flow to display. "
+            "May be provided as a filename or a raw string "
+            "representing a JSON object or YAML definition."
         ),
         callback=input_validator,
         show_default=False,
@@ -797,7 +801,9 @@ def flow_actions_list(
         None,
         "--per-page",
         "-p",
-        help="The page size to return. Only valid when used without providing a marker.",
+        help=(
+            "The page size to return. Only valid when used without providing a marker."
+        ),
         min=1,
         max=50,
     ),
@@ -847,7 +853,7 @@ def flow_actions_list(
     role_param = make_role_param(roles)
 
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
-    callable = functools.partial(
+    method = functools.partial(
         fc.list_flow_actions,
         flow_id=flow_id,
         flow_scope=flow_scope,
@@ -859,7 +865,7 @@ def flow_actions_list(
         **role_param,
     )
     RequestRunner(
-        callable,
+        method,
         format=output_format,
         verbose=verbose,
         watch=watch,
@@ -933,10 +939,10 @@ def flow_action_resume(
     ),
     verbose: bool = verbosity_option,
 ):
-    """Resume a Flow in the INACTIVE state. If query-for-inactive-reason is set, and the
-    Flow Action is in an INACTIVE state due to requiring additional Consent, the required
-    Consent will be determined and you may be prompted to allow Consent using the Globus
-    Auth web interface.
+    """Resume a Flow in the INACTIVE state. If query-for-inactive-reason is set,
+    and the Flow Action is in an INACTIVE state due to requiring additional Consent,
+    the required Consent will be determined, and you may be prompted to allow Consent
+    using the Globus Auth web interface.
     """
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
     if query_for_inactive_reason:
@@ -1045,12 +1051,12 @@ def flow_action_log(
     reverse: bool = typer.Option(
         False,
         "--reverse",
-        help="Display logs starting from most recent and proceeding in reverse chronological order",
+        help="Display logs reverse chronological order (most recent first).",
         show_default=True,
     ),
     limit: int = typer.Option(
         None,
-        help="Set a maximum number of events from the log to return",
+        help="Set a maximum number of events from the log to return.",
         min=1,
         max=100,
     ),
@@ -1064,7 +1070,9 @@ def flow_action_log(
         None,
         "--per-page",
         "-p",
-        help="The page size to return. Only valid when used without providing a marker.",
+        help=(
+            "The page size to return. Only valid when used without providing a marker."
+        ),
         min=1,
         max=50,
     ),
@@ -1156,7 +1164,9 @@ def flow_action_enumerate(
         None,
         "--per-page",
         "-p",
-        help="The page size to return. Only valid when used without providing a marker.",
+        help=(
+            "The page size to return. Only valid when used without providing a marker."
+        ),
         min=1,
         max=50,
     ),

--- a/tests/test_flows_client.py
+++ b/tests/test_flows_client.py
@@ -242,33 +242,46 @@ def test_deploy_flow_dry_run(fc, mocked_responses, dry_run, path):
     assert mocked_responses.calls[0].request.url == url
 
 
-def test_deploy_flow_aliases(fc, mocked_responses):
+def test_deploy_flow_aliases_batch_1(fc, mocked_responses):
     """Verify that viewer/starter/admin aliases are still supported."""
 
     mocked_responses.add("POST", f"{flows_client.PROD_FLOWS_BASE_URL}/flows")
-    fc.deploy_flow(
-        # Flow viewers and aliases
-        flow_viewers=["v1", "v2"],
-        visible_to=["v3"],
-        viewers=["v4"],
-        # Flow starters and aliases
-        flow_starters=["s1", "s2"],
-        runnable_by=["s3"],
-        starters=["s4"],
-        # Flow admins and aliases
-        flow_administrators=["a1", "a2"],
-        administered_by=["a3"],
-        administrators=["a4"],
-        # Everything below is mandatory but irrelevant to this test.
-        flow_definition=VALID_FLOW_DEFINITION,
-        title="",
-        validate_definition=False,
-        validate_schema=False,
-    )
+    with pytest.warns(DeprecationWarning):
+        fc.deploy_flow(
+            visible_to=["v1"],
+            runnable_by=["s1"],
+            administered_by=["a1"],
+            # Everything below is mandatory but irrelevant to this test.
+            flow_definition=VALID_FLOW_DEFINITION,
+            title="",
+            validate_definition=False,
+            validate_schema=False,
+        )
     data = json.loads(mocked_responses.calls[0].request.body)
-    assert set(data["flow_viewers"]) == {"v1", "v2", "v3", "v4"}
-    assert set(data["flow_starters"]) == {"s1", "s2", "s3", "s4"}
-    assert set(data["flow_administrators"]) == {"a1", "a2", "a3", "a4"}
+    assert set(data["flow_viewers"]) == {"v1"}
+    assert set(data["flow_starters"]) == {"s1"}
+    assert set(data["flow_administrators"]) == {"a1"}
+
+
+def test_deploy_flow_aliases_batch_2(fc, mocked_responses):
+    """Verify that viewer/starter/admin aliases are still supported."""
+
+    mocked_responses.add("POST", f"{flows_client.PROD_FLOWS_BASE_URL}/flows")
+    with pytest.warns(DeprecationWarning):
+        fc.deploy_flow(
+            viewers=["v2"],
+            starters=["s2"],
+            administrators=["a2"],
+            # Everything below is mandatory but irrelevant to this test.
+            flow_definition=VALID_FLOW_DEFINITION,
+            title="",
+            validate_definition=False,
+            validate_schema=False,
+        )
+    data = json.loads(mocked_responses.calls[0].request.body)
+    assert set(data["flow_viewers"]) == {"v2"}
+    assert set(data["flow_starters"]) == {"s2"}
+    assert set(data["flow_administrators"]) == {"a2"}
 
 
 @pytest.mark.parametrize("method", ("deploy_flow", "update_flow"))
@@ -362,34 +375,48 @@ def test_update_flow_exclude_most_false_values(
     assert ("input_schema" in data) is expected
 
 
-def test_update_flow_aliases(fc, mocked_responses):
+def test_update_flow_aliases_batch_1(fc, mocked_responses):
     """Verify that viewer/starter/admin aliases are still supported."""
 
     mocked_responses.add("PUT", f"{flows_client.PROD_FLOWS_BASE_URL}/flows/bogus")
-    fc.update_flow(
-        # Flow viewers and aliases
-        flow_viewers=["v1", "v2"],
-        visible_to=["v3"],
-        viewers=["v4"],
-        # Flow starters and aliases
-        flow_starters=["s1", "s2"],
-        runnable_by=["s3"],
-        starters=["s4"],
-        # Flow admins and aliases
-        flow_administrators=["a1", "a2"],
-        administered_by=["a3"],
-        administrators=["a4"],
-        # Everything below is mandatory but irrelevant to this test.
-        flow_id="bogus",
-        flow_definition=VALID_FLOW_DEFINITION,
-        title="",
-        validate_definition=False,
-        validate_schema=False,
-    )
+    with pytest.warns(DeprecationWarning):
+        fc.update_flow(
+            visible_to=["v1"],
+            runnable_by=["s1"],
+            administered_by=["a1"],
+            # Everything below is mandatory but irrelevant to this test.
+            flow_id="bogus",
+            flow_definition=VALID_FLOW_DEFINITION,
+            title="",
+            validate_definition=False,
+            validate_schema=False,
+        )
     data = json.loads(mocked_responses.calls[0].request.body)
-    assert set(data["flow_viewers"]) == {"v1", "v2", "v3", "v4"}
-    assert set(data["flow_starters"]) == {"s1", "s2", "s3", "s4"}
-    assert set(data["flow_administrators"]) == {"a1", "a2", "a3", "a4"}
+    assert set(data["flow_viewers"]) == {"v1"}
+    assert set(data["flow_starters"]) == {"s1"}
+    assert set(data["flow_administrators"]) == {"a1"}
+
+
+def test_update_flow_aliases_batch_2(fc, mocked_responses):
+    """Verify that viewer/starter/admin aliases are still supported."""
+
+    mocked_responses.add("PUT", f"{flows_client.PROD_FLOWS_BASE_URL}/flows/bogus")
+    with pytest.warns(DeprecationWarning):
+        fc.update_flow(
+            viewers=["v2"],
+            starters=["s2"],
+            administrators=["a2"],
+            # Everything below is mandatory but irrelevant to this test.
+            flow_id="bogus",
+            flow_definition=VALID_FLOW_DEFINITION,
+            title="",
+            validate_definition=False,
+            validate_schema=False,
+        )
+    data = json.loads(mocked_responses.calls[0].request.body)
+    assert set(data["flow_viewers"]) == {"v2"}
+    assert set(data["flow_starters"]) == {"s2"}
+    assert set(data["flow_administrators"]) == {"a2"}
 
 
 def test_get_flow(fc, mocked_responses):


### PR DESCRIPTION
Bugfixes
--------

-   [\[sc-13892\]](https://app.shortcut.com/globus/story/13892)    Standardize flow viewer, starter, and administrator arguments -- and their aliases -- throughout the CLI and API.

    Although this change fixes bugs that prevented documented CLI options from working,
    it also introduces breaking changes:

    *   ``--flow-viewer``, ``--flow-starter``, and ``--flow-administrator`` are the canonical CLI options.
    *   The CLI option aliases will continue to work, but the alias behavior has changed:

        *   If an alias is used, a warning is written to STDERR.
        *   If the canonical option name is combined with one of its aliases,
            an error will be written to STDERR and the Automate client will exit.
            The exit code will be 1.
        *   If more than one of the acceptable aliases is used (like ``--starter`` and ``--runnable-by``),
            an error will be written to STDERR and the Automate client will exit.
            The exit code will be 1.

    In addition, there are breaking changes in the API:

    *   ``flow_viewers``, ``flow_starters``, and ``flow_administrators`` are the canonical API argument names.
    *   The API argument aliases will continue to work, but the alias behavior has changed:

        *   If an alias is used, a Python warning will be issued.
            Applications can control the warning behavior using Python's ``warnings`` module.
        *   If the canonical option name is combined with one of its aliases, a ``ValueError`` will be raised.
        *   If more than one of the acceptable aliases is used (like ``starters`` and ``runnable_by``), a ``ValueError`` will be raised.
