### PR TITLE
Add explicit github user handles to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # The automate team will be requested for review on all opened PRs.
-* @globusonline/automate @ada-globus @joshbryan-globus @kurtmckee @rudyardrichter @jakeglobus
+* @globus/automate @ada-globus @joshbryan-globus @kurtmckee @rudyardrichter @jakeglobus

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The automate team will be requested for review on all opened PRs.
+* @globusonline/automate @ada-globus @joshbryan-globus @kurtmckee @rudyardrichter @jakeglobus


### PR DESCRIPTION
Adds CODEOWNERS file with explicit github user handles in order to work around limitations when we just rely on the group.