### PR TITLE
Fix example flow definition: web-option-with-parameters

### DIFF
--- a/changelog.d/20220830_105958_nick_fix_web_option_with_parameters.rst
+++ b/changelog.d/20220830_105958_nick_fix_web_option_with_parameters.rst
@@ -1,0 +1,7 @@
+.. A new scriv changelog fragment.
+..
+Documentation
+-------------
+
+- Fix example flow definition web-option-with-parameters
+

--- a/examples/flows/web-option-with-parameters/definition.json
+++ b/examples/flows/web-option-with-parameters/definition.json
@@ -19,16 +19,12 @@
             "name": "b",
             "description": "This is option b",
             "url_suffix": "jcp_option_b_new",
-            "include_body": true,
-            "include_query_params": true,
             "completed_message": "Thank you for selecting 'b'"
           },
           {
             "name": "default",
             "description": "This is the default option",
             "url_suffix": "jcp_option_a_new",
-            "include_body": true,
-            "include_query_params": true,
             "completed_message": "Thank you for selecting the default option"
           }
         ]


### PR DESCRIPTION
The web-option-with-parameters definition had some invalid, possibly old,
values which would cause the AP to 500 when deployed and run. Removing
these fixes the flow.