### PR TITLE
Update Action Provider Documentation Details

### DIFF
--- a/docs/source/authoring_flows.rst
+++ b/docs/source/authoring_flows.rst
@@ -216,7 +216,7 @@ parameters are not sufficient. Thus, we introduce expression type parameters
 which may evaluate multiple parts of the state to compute a single, required
 value.
 
-The syntax of an expression paramter takes the following form:
+The syntax of an expression parameter takes the following form:
 
 .. code-block:: JSON
 
@@ -271,7 +271,7 @@ In addition to basic arithmetic operations, a few *functions* may be used. Funct
 
   * ``getattr('x', 10)``: returns the value of property ``x`` if it is present, and the constant 10 if not (equivalent to the ``is_present`` example above.
 
-  * ``getattr('missing_property')``: Would return a ``null` value if the ``missing_property`` value is not present in the state.
+  * ``getattr('missing_property')``: Would return a ``null`` value if the ``missing_property`` value is not present in the state.
 
 Identities and Roles, Scopes and Tokens
 ---------------------------------------

--- a/docs/source/globus_action_providers.rst
+++ b/docs/source/globus_action_providers.rst
@@ -403,6 +403,21 @@ should be used in the Datacite test service or the production service.
    :language: json
    :caption: Example Input
 
+
+funcX
+-----
+
+URL: `<https://automate.funcx.org>`_
+
+Scope: ``https://auth.globus.org/scopes/b3db7e59-a6f1-4947-95c2-59d6b7a70f8c/action_all``
+
+Synchronous / Asynchronous: Asynchronous
+
+FuncX supports an asynchronous action provider to provide access via the Globus
+Automate ecosystem. More details can be found `in the funcX documentation
+<https://funcx.readthedocs.io/en/latest/actionprovider.html>`_.
+
+
 .. _Globus Transfer ACL API: https://docs.globus.org/api/transfer/acl/
 .. _Globus Transfer Task API: https://docs.globus.org/api/transfer/task_submit/
 .. _Globus Transfer Directory API: https://docs.globus.org/api/transfer/file_operations/#list_directory_contents

--- a/docs/source/globus_action_providers.rst
+++ b/docs/source/globus_action_providers.rst
@@ -173,7 +173,8 @@ Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/tra
 Synchronous / Asynchronous: Synchronous
 
 The Globus Transfer ls Action Provider uses the `Globus Transfer Get Collection API`_
-to get information about a Globus Collection. The information returned is the same as defined by the Globus Transfer API with one addition: a property ``is_managed`` will be set to ``true`` if there is a ``subscription_id`` associated with the collection, and ``false`` if not. This allows, for example, branching within a Flow (using a ``Choice`` state type) based on whether a collection/endpoint is managed under a Globus subscription.
+to get information about a Globus Collection. The information returned is the same as defined by the Globus Transfer API with one addition: a property ``is_managed``. When ``true``, the ``is_managed`` property indicates that a collection (or its host) is managed under a Globus subscription.
+
 
 Globus Search - Ingest
 ----------------------


### PR DESCRIPTION
- Adds an entry for the funcX AP with a link back to the funcX docs
- Tweaks the language regarding the `is_managed` fields on the collection info AP
- Fixes a couple small typos in the Authoring Flows section