### PR TITLE
Apply an edit pass to fix several docs issues

### DIFF
--- a/changelog.d/20221113_160825_ada_docs_edits.rst
+++ b/changelog.d/20221113_160825_ada_docs_edits.rst
@@ -1,0 +1,5 @@
+Documentation
+-------------
+
+- Improve documentation by normalizing capitalization and emphasis, as well as
+  clarifying usage of "Globus Automate" wherever it occurred.

--- a/docs/source/authoring_flows.rst
+++ b/docs/source/authoring_flows.rst
@@ -5,8 +5,8 @@ Authoring Flows for the Globus Flows Service
 
 *Globus Flows* provides users with the ability to easily define
 compositions of actions (henceforth referred to as *flows*) to perform a single,
-logical operation. Definition of such flows requires an easy to read, author,
-and potentially visualize method of defining the flows. For this purpose, the
+logical operation. The method for defining such flows must be easy to read, author,
+and potentially visualize. For this purpose, the
 Flows service starts from the core of the `Amazon States Language
 <https://states-language.net/spec.html>`_. In particular, the general structure
 of a flow matches that of a States Language state machine in particular matching

--- a/docs/source/authoring_flows.rst
+++ b/docs/source/authoring_flows.rst
@@ -3,13 +3,13 @@
 Authoring Flows for the Globus Flows Service
 ============================================
 
-The Globus Flows Service provides users with the ability to easily define
-compositions of Actions (henceforth referred to as Flows) to perform a single,
-logical operation. Definition of such Flows requires an easy to read, author,
-and potentially visualize method of defining the Flows. For this purpose, the
+*Globus Flows* provides users with the ability to easily define
+compositions of actions (henceforth referred to as *flows*) to perform a single,
+logical operation. Definition of such flows requires an easy to read, author,
+and potentially visualize method of defining the flows. For this purpose, the
 Flows service starts from the core of the `Amazon States Language
 <https://states-language.net/spec.html>`_. In particular, the general structure
-of a Flow matches that of a States Language State Machine in particular matching
+of a flow matches that of a States Language state machine in particular matching
 the requirements defined for `Top-Level Fields
 <https://states-language.net/spec.html#toplevelfields>`_ including the
 properties:
@@ -21,13 +21,13 @@ properties:
 * ``Comment``
 
 Additionally, general concepts from the States Language and its method of
-managing state for the State Machine/Flow are maintained. Concepts such as
+managing state for the state machine/flow are maintained. Concepts such as
 `Input and Output Processing <https://states-language.net/spec.html#filters>`_
 are handled in the same manner (see note below for an important exception). In
-particular, paths within the state of the Flow are referenced with a ``$.``
+particular, paths within the state of the flow are referenced with a ``$.``
 prefix just as defined in the States Language.
 
-The following state types are supported in Flows in nearly (see note
+The following state types are supported in flows in nearly (see note
 below) the same manor as defined in the States Language:
 
 * `Pass <https://states-language.net/spec.html#pass-state>`_
@@ -42,18 +42,18 @@ below) the same manor as defined in the States Language:
 
    The exception is the use of the ``OutputPath`` property in
    the ``Pass`` or ``Choice`` states. ``OutputPath`` is not allowed in
-   a Flow definition. Instead, the ``ResultPath`` must always be used
+   a flow definition. Instead, the ``ResultPath`` must always be used
    to specify where the result of a state execution will be stored
-   into the state of the Flow.
+   into the state of the flow.
 
-Other state types defined in the Amazon States Language are not supported and will be rejected at deployment time. The Flows system adds two new state types ``Action`` and ``ExpressionEval`` for invoking Actions and updating the state of a running Flow via an expression language. These are defined below.
+Other state types defined in the Amazon States Language are not supported and will be rejected at deployment time. The Flows service adds two new state types ``Action`` and ``ExpressionEval`` for invoking actions and updating the state of a running flow via an expression language. These are defined below.
 
-``Action`` State type
+``Action`` State Type
 ---------------------
 
-As Actions are the core building block for most concepts in Globus Automate,
-Action invocation takes on a central role in the definition of Flows. Actions
-are invoked from a Flow using the state type ``Action``. We describe the
+As actions are the core building block for most concepts in the Globus automation
+services, action invocation takes on a central role in the definition of flows. Actions
+are invoked from a flow using the state type ``Action``. We describe the
 structure of an ``Action`` state via the following example which is described in
 detail below:
 
@@ -61,7 +61,7 @@ detail below:
 
     {
       "Type": "Action",
-      "ActionUrl": "<URL to the Action, as defined above for various Actions>",
+      "ActionUrl": "<URL to the action, as defined above for various actions>",
       "InputPath": "$.Path.To.Action.Body",
       "Parameters": {
         "constant_val": 10,
@@ -89,7 +89,7 @@ detail below:
         }
       ],
       "Next": "FollowingState",
-      "ActionScope": "<Scope String for the Action, as defined above for various Actions>",
+      "ActionScope": "<Scope String for the action, as defined above for various actions>",
       "End": true
     }
 
@@ -97,56 +97,56 @@ The properties on the ``Action`` state are defined as follows. In some
 cases, we provide additional discussion of topics raised by specific properties
 in further sections below this enumeration.
 
-* ``Type`` (required): As with other States defined by the States Language, the ``Type`` indicates the type of this state. The value ``Action`` indicates that this state represents an Action invocation.
+* ``Type`` (required): As with other States defined by the States Language, the ``Type`` indicates the type of this state. The value ``Action`` indicates that this state represents an action invocation.
 
-*  ``ActionUrl`` (required): The base URL of the Action. As defined by the Action Interface, this URL has methods such as ``/run``, ``/status``, ``/cancel`` and so on defined to manage the life-cycle of an Action. The Action Flow state manages the life-cycle of the invoked Action using these methods and assumes that the specific operations are appended to the base URL defined in this property. For Globus operated actions, the base URLs are as defined previously in this document.
+*  ``ActionUrl`` (required): The base URL of the action. As defined by the Action Interface, this URL has methods such as ``/run``, ``/status``, ``/cancel`` and so on defined to manage the life-cycle of an action. The Action flow state manages the life-cycle of the invoked action using these methods and assumes that the specific operations are appended to the base URL defined in this property. For Globus operated actions, the base URLs are as defined previously in this document.
 
-*  ``InputPath`` or ``Parameters`` (mutually exclusive options, at least one is required): Either ``InputPath`` or ``Parameters`` can be used to identify or form the input to the Action to be run as passed in the ``body`` of the call to the action ``/run`` operation.
+*  ``InputPath`` or ``Parameters`` (mutually exclusive options, at least one is required): Either ``InputPath`` or ``Parameters`` can be used to identify or form the input to the action to be run as passed in the ``body`` of the call to the action ``/run`` operation.
 
-   *  ``Parameters``: The Parameters property is defined as an object that becomes the input to the Action. As such, it becomes relatively plain in the ``Action`` state definition that the structure of the ``Parameters`` object matches the structure of the body of the input to the Action being invoked. Some of the fields in the ``Parameters`` object can be protected from introspection later so that secret or sensitive information, such as credentials, can be encoded in the parameter values without allowing visibility outside the flow, including by those running the Flow. The private parameter functionality is described in `Protecting Action and Flow State`_. Values in ``Parameters`` can be specified in a variety of ways:
+   *  ``Parameters``: The Parameters property is defined as an object that becomes the input to the action. As such, it becomes relatively plain in the ``Action`` state definition that the structure of the ``Parameters`` object matches the structure of the body of the input to the action being invoked. Some of the fields in the ``Parameters`` object can be protected from introspection later so that secret or sensitive information, such as credentials, can be encoded in the parameter values without allowing visibility outside the flow, including by those running the Flow. The private parameter functionality is described in `Protecting Action and Flow State`_. Values in ``Parameters`` can be specified in a variety of ways:
 
       *  **Constants**: Simply specify a value which will always be passed for that property. Constants can be any type: numeric, string, boolean or other objects should an action body specify sub-objects as part of their input. When an object is used, each of the properties within the object can also be of any of the types enumerated here.
 
-      *  **References**: Copies values from the state of the flow to the name given. The name must end with the sequence ``.$`` to indicate that a reference is desired, and the string-type value must be a `Json Path <https://goessner.net/articles/JsonPath/>`_ starting with the characters ``$.`` indicating the location in the Flow run-time state that values should be retrieved from.
+      *  **References**: Copies values from the state of the flow to the name given. The name must end with the sequence ``.$`` to indicate that a reference is desired, and the string-type value must be a `Json Path <https://goessner.net/articles/JsonPath/>`_ starting with the characters ``$.`` indicating the location in the flow run-time state that values should be retrieved from.
 
-      *  **Expressions**: Allow values to be computed as a combination of constants and references to other state in the Flow's run-time. This provides a powerful mechanism for deriving parameter values and is defined more fully below in `Expressions in Parameters`_
+      *  **Expressions**: Allow values to be computed as a combination of constants and references to other state in the flow's run-time. This provides a powerful mechanism for deriving parameter values and is defined more fully below in `Expressions in Parameters`_
 
-   *  ``InputPath``: Specifies a path within the existing state of the Flow here the values to be passed will be present. Thus, use of ``InputPath`` requires that the proper input be formed in the Flow state.
+   *  ``InputPath``: Specifies a path within the existing state of the flow here the values to be passed will be present. Thus, use of ``InputPath`` requires that the proper input be formed in the flow state.
 
-*  ``ResultPath``: Is a `Reference Path <https://states-language.net/spec.html#ref-paths>`_ indicating where the output of the Action will be placed in the state of the Flow run-time. The entire output returned from the Action will be returned including the ``action_id``, the final ``status`` of the Action, the ``start_time`` and ``completion_time`` and, importantly, the ``details`` containing the action-specific result values. If ``ResultPath`` is not explicitly provided, the default value of simply ``$``, indicating the root of the Flow state, is assumed and thus the result of the Action will become the entire Flow state following the ``Action`` state's execution. Typically this is not the desired behavior, so a ``ResultPath`` should almost always be included.
+*  ``ResultPath``: Is a `Reference Path <https://states-language.net/spec.html#ref-paths>`_ indicating where the output of the action will be placed in the state of the flow run-time. The entire output returned from the action will be returned including the ``action_id``, the final ``status`` of the action, the ``start_time`` and ``completion_time`` and, importantly, the ``details`` containing the action-specific result values. If ``ResultPath`` is not explicitly provided, the default value of simply ``$``, indicating the root of the flow state, is assumed and thus the result of the action will become the entire flow state following the ``Action`` state's execution. Typically this is not the desired behavior, so a ``ResultPath`` should almost always be included.
 
-*  ``WaitTime`` (optional, default value ``300``): The maximum amount time to wait for the Action to complete in seconds. Upon execution, the Flow will monitor the execution of the Action for the specified amount of time, and if it does not complete by this time it will abort the Action. See `Action Execution Monitoring`_ for additional information on this. The default value is ``300`` or Five Minutes.
+*  ``WaitTime`` (optional, default value ``300``): The maximum amount time to wait for the action to complete in seconds. Upon execution, the flow will monitor the execution of the action for the specified amount of time, and if it does not complete by this time it will abort the action. See `Action Execution Monitoring`_ for additional information on this. The default value is ``300`` or Five Minutes.
 
-*  ``ExceptionOnActionFailure`` (optional, default value ``true``): When an Action is executed but is unable complete successfully, it returns a ``status`` value of ``FAILED``. It is commonly useful to treat this "Action Failed" occurrence as an Exception in the execution of the Flow. Setting this property to ``true`` will cause a Run-time exception of type ``ActionFailedException`` to be raised which can be managed with a ``Catch`` statement (as shown in the example). Further details on discussion of the ``Catch`` property of the Action state and in the `Managing Exceptions`_ section. If the value is ``false``, the status of the Action, including the value of ``FAILED`` for the status value will be placed into the Flow state as referenced by ``ResultPath``.
+*  ``ExceptionOnActionFailure`` (optional, default value ``true``): When an action is executed but is unable complete successfully, it returns a ``status`` value of ``FAILED``. It is commonly useful to treat this "Action Failed" occurrence as an Exception in the execution of the flow. Setting this property to ``true`` will cause a run-time exception of type ``ActionFailedException`` to be raised which can be managed with a ``Catch`` statement (as shown in the example). Further details on discussion of the ``Catch`` property of the action state and in the `Managing Exceptions`_ section. If the value is ``false``, the status of the action, including the value of ``FAILED`` for the status value will be placed into the flow state as referenced by ``ResultPath``.
 
-*  ``RunAs`` (optional, default value ``User``): When the Flow executes the Action, it will, by default, execute the Action using the identity of the user invoking the Flow. Thus, from the perspective of the Action, it is the user who invoked the Flow who is also invoking the Action, and thus the Action will make authorization decisions based on the identity of the User invoking the Flow. In some circumstances, it will be beneficial for the Action to be invoked as if from a user identity other than the user who invoked the Flow. See `Identities and Roles, Scopes and Tokens`_ for additional information and a discussion of use cases for providing different ``RunAs`` values.
+*  ``RunAs`` (optional, default value ``User``): When the flow executes the action, it will, by default, execute the action using the identity of the user invoking the flow. Thus, from the perspective of the action, it is the user who invoked the flow who is also invoking the action, and thus the action will make authorization decisions based on the identity of the User invoking the flow. In some circumstances, it will be beneficial for the action to be invoked as if from a user identity other than the user who invoked the flow. See `Identities and Roles, Scopes and Tokens`_ for additional information and a discussion of use cases for providing different ``RunAs`` values.
 
-*   ``Catch``: When Actions end abnormally, an Exception is raised. A ``Catch`` property defines how the Exception should be handled by identifying the Exception name in the ``ErrorEquals`` property and identifying a ``Next`` state to transition to when the Exception occurs. If no ``Catch`` can handle an exception, the Flow execution will abort on the Exception. A variety of exception types are defined and are enumerated in `Managing Exceptions`_.
+*   ``Catch``: When actions end abnormally, an Exception is raised. A ``Catch`` property defines how the Exception should be handled by identifying the Exception name in the ``ErrorEquals`` property and identifying a ``Next`` state to transition to when the Exception occurs. If no ``Catch`` can handle an exception, the flow execution will abort on the Exception. A variety of exception types are defined and are enumerated in `Managing Exceptions`_.
 
-*  ``ActionScope`` (optional): The scope string to be used when authenticating to access the Action. In most cases, this values is unneeded because the required scope can be determined by querying the Action Provider using the provided ``ActionUrl``. If you are using a non-standard compliant Action which does not publish its ``scope``, this can be provided to avoid attempting to query the non-compliant Action provider.
+*  ``ActionScope`` (optional): The scope string to be used when authenticating to access the action. In most cases, this values is unneeded because the required scope can be determined by querying the action provider using the provided ``ActionUrl``. If you are using a non-standard compliant action which does not publish its ``scope``, this can be provided to avoid attempting to query the non-compliant action provider.
 
-*   ``Next`` or ``End`` (mutually exclusive, one required): These indicate how the Flow should proceed after the Action state. ``Next`` indicates the name of the following state of the flow, and ``End`` with a value ``true`` indicates that the Flow is complete after this state completes.
+*   ``Next`` or ``End`` (mutually exclusive, one required): These indicate how the flow should proceed after the action state. ``Next`` indicates the name of the following state of the flow, and ``End`` with a value ``true`` indicates that the flow is complete after this state completes.
 
 Protecting Action and Flow State
 --------------------------------
 
-At times, portions of a Flow state may need to be secret or protected from the
+At times, portions of a flow state may need to be secret or protected from the
 various operations, like status and log, which can be used to monitor and
-observe the state of a Flow execution. For example, some Actions may require
+observe the state of a flow execution. For example, some actions may require
 credentials or keys to authenticate or permit access. These items should not be
 visible to some users, particularly when they are encoded (e.g. in Parameter
-constants) by the Flow author. There are two areas where these values may be
-stored or encoded: in ``Parameters`` to Actions, and within the state of the
-Flow at run-time. The service provides mechanisms for protecting information in
+constants) by the flow author. There are two areas where these values may be
+stored or encoded: in ``Parameters`` to actions, and within the state of the
+flow at run-time. The service provides mechanisms for protecting information in
 both cases.
 
 For ``Parameters``, a list with special property name ``__Private_Parameters``
 may be placed in the ``Parameters`` object indicating which other Parameters
 should be protected. These values will be protected in two ways:
 
-* Users that lookup the Flow in the service will not see the ``Parameters`` which are specified in the ``__Private_Parameters`` list unless they have the ``flow_administrator`` or ``flow_owner`` role on the Flow.
+* Users that lookup the flow in the service will not see the ``Parameters`` which are specified in the ``__Private_Parameters`` list unless they have the ``flow_administrator`` or ``flow_owner`` role on the flow.
 
-* When the state of a run of the Flow is returned, values for these ``Parameters`` will not be returned in the status or log of the Flow's execution.
+* When the state of a run of the flow is returned, values for these ``Parameters`` will not be returned in the status or log of the flow's execution.
 
 For simplicity, the values in the ``__Private_Parameters``
 list may include the "simple" name even when the parameter name is a Reference
@@ -173,11 +173,11 @@ definition:
 
 
 The ``password`` property within the ``server_info`` object would be omitted
-from output of any state of the Flow retrieved by any user.
+from output of any state of the flow retrieved by any user.
 
-To protect the state of the Flow's run-time, any property which starts with the
-prefix ``_private`` will be omitted from Flow introspection. Thus, if protected
-values need to be stored within the Flow state, they could be stored in a
+To protect the state of the flow's run-time, any property which starts with the
+prefix ``_private`` will be omitted from flow introspection. Thus, if protected
+values need to be stored within the flow state, they could be stored in a
 property with a name like ``_private_secret_property`` or in an object simply
 having the name ``_private`` as that object, starting with the prefix will
 entirely be omitted from the output. As an example, the following flow state
@@ -198,7 +198,7 @@ such as in an Action parameter. Thus, the reference path
 ``$._private.password`` could be used and the value ``my_password`` would be
 used for the parameter. In such a case, that parameter would also most likely
 need to appear in the ``__Private_Parameters`` list to prevent the value from
-being shown when the state of the particular Action is displayed to a user.
+being shown when the state of the particular action is displayed to a user.
 Thus, the state protection via ``_private`` property names and the enumeration
 of protected parameters via ``__Private_Parameters`` will often be used in
 tandem.
@@ -208,10 +208,10 @@ tandem.
 Expressions in Parameters
 -------------------------
 
-Action Parameters allow the inputs to an Action to be formed from different
-parts of the Flow run-time state. However, the reference approach requires that
-the exact value needed be present in the Flow's state. If the required value is
-somehow to be derived from multiple values in the Flow state, reference
+Action Parameters allow the inputs to an action to be formed from different
+parts of the flow run-time state. However, the reference approach requires that
+the exact value needed be present in the flow's state. If the required value is
+somehow to be derived from multiple values in the flow state, reference
 parameters are not sufficient. Thus, we introduce expression type parameters
 which may evaluate multiple parts of the state to compute a single, required
 value.
@@ -231,7 +231,7 @@ expression languages. This includes common arithmetic operators on numeric
 values as well as operations on strings (e.g. string concatenation via a `+`
 operation) and on lists (similarly the `+` operator will concatenate lists).
 
-The values in the state of the flow may be used in the expression and are denoted as ``<state_valN>`` above. For the following description, assume that the input to (or current state of) a Flow Run is as follows:
+The values in the state of the flow may be used in the expression and are denoted as ``<state_valN>`` above. For the following description, assume that the input to (or current state of) a flow run is as follows:
 
 .. code-block:: JSON
 
@@ -276,21 +276,21 @@ In addition to basic arithmetic operations, a few *functions* may be used. Funct
 Identities and Roles, Scopes and Tokens
 ---------------------------------------
 
-The ``RunAs`` property of an ``Action`` state can be used to control the identity associated with executing the Action. In most cases, it will be appropriate to have the Action invoked as the same identity that invoked the Flow. This is the default behavior, so no value for ``RunAs`` is needed to get this behavior. However, other scenarios may require a single Flow execution to invoke various Actions using different identities or roles. The ``RunAs`` property of the ``Action`` state provides two additional types of roles that can be specified:
+The ``RunAs`` property of an ``Action`` state can be used to control the identity associated with executing the action. In most cases, it will be appropriate to have the action invoked as the same identity that invoked the flow. This is the default behavior, so no value for ``RunAs`` is needed to get this behavior. However, other scenarios may require a single flow execution to invoke various actions using different identities or roles. The ``RunAs`` property of the ``Action`` state provides two additional types of roles that can be specified:
 
-*  ``Flow``: When the value is ``Flow``, the Action will be invoked as the identity of the Flow itself. Because every Flow is registered with the Globus Auth system so that it can authenticate requests to be run, it also has a unique identity in Globus Auth. This identity can be used to invoke other Actions. Thus, once the Flow is deployed, the Globus Auth identity of the Flow is known, and can be configured in the authorization state of various Actions for permission. To help with this form of configuration, the information provided by a flow using the command ``globus-automate flow list`` or ``globus-automate flow display`` includes two properties which help identity the Flow. The first is ``principal_urn`` which provides the URN form of the identity for the Flow which is used by many Actions and other Globus services to specify identities. The other property is ``globus_auth_username`` which is another common method of naming a Globus Auth identity.
+*  ``Flow``: When the value is ``Flow``, the action will be invoked as the identity of the flow itself. Because every flow is registered with the Globus Auth system so that it can authenticate requests to be run, it also has a unique identity in Globus Auth. This identity can be used to invoke other actions. Thus, once the flow is deployed, the Globus Auth identity of the flow is known, and can be configured in the authorization state of various actions for permission. To help with this form of configuration, the information provided by a flow using the command ``globus-automate flow list`` or ``globus-automate flow display`` includes two properties which help identity the flow. The first is ``principal_urn`` which provides the URN form of the identity for the flow which is used by many actions and other Globus services to specify identities. The other property is ``globus_auth_username`` which is another common method of naming a Globus Auth identity.
 
-* An arbitrary "role name" can also be specified as in ``"RunAs": "AdminUser"``. The identity for this role will be determined by an additional Globus Auth access token which is passed into the Flow at run-time as part of the initial state. The flows service will use this token when invoking the Action and so the Action will see the request as if coming from the user associated with this token. We describe how these role-specific tokens are passed next.
+* An arbitrary "role name" can also be specified as in ``"RunAs": "AdminUser"``. The identity for this role will be determined by an additional Globus Auth access token which is passed into the flow at run-time as part of the initial state. The flows service will use this token when invoking the action and so the action will see the request as if coming from the user associated with this token. We describe how these role-specific tokens are passed next.
 
 .. note::
 
-   When a Flow is run, the identity of the running user is determined
+   When a flow is run, the identity of the running user is determined
    by examining the token passed on the header of the HTTP request,
    and, as described in the next section, other tokens may be passed
    in the body of the request. In either case, the Flows service will
    validate the token by interacting with the Globus Auth
    service. These interactions with Globus Auth require additional
-   time when a Flow is being started. To help alleviate this overhead,
+   time when a flow is being started. To help alleviate this overhead,
    the Flows service will retain (cache) results from token validity
    checks for up to 30 seconds. That is, if the same token is
    presented more than once within 30 seconds, the results from the
@@ -304,7 +304,7 @@ The ``RunAs`` property of an ``Action`` state can be used to control the identit
 Providing Role-Specific Tokens
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When ``RunAs`` specifies a role name, corresponding tokens must be generated and provided to the Flow at run-time. The necessary information to generate any Globus Auth token is the name of the scope to which the token should be generated. So that generated tokens are as specific as possible, the Flows service creates a separate scope for each role which appears as part of a ``RunAs`` property. These scope strings are present in the Flow description under the property ``globus_auth_scopes_by_RunAs``. This will be a JSON object with the property names matching the roles named in ``RunAs`` and the values being the Globus Auth scope string. For example, if roles named ``Admin`` and ``Curator`` were present in the Flow definition, the Flow description would contain an object like:
+When ``RunAs`` specifies a role name, corresponding tokens must be generated and provided to the flow at run-time. The necessary information to generate any Globus Auth token is the name of the scope to which the token should be generated. So that generated tokens are as specific as possible, the flows service creates a separate scope for each role which appears as part of a ``RunAs`` property. These scope strings are present in the flow description under the property ``globus_auth_scopes_by_RunAs``. This will be a JSON object with the property names matching the roles named in ``RunAs`` and the values being the Globus Auth scope string. For example, if roles named ``Admin`` and ``Curator`` were present in the flow definition, the flow description would contain an object like:
 
 .. code-block:: JSON
 
@@ -313,7 +313,7 @@ When ``RunAs`` specifies a role name, corresponding tokens must be generated and
      "Curator": "Globus Auth Scope String for Curator>"
    }
 
-When invoking the Flow (e.g. via ``globus-automate flow run``) the flow input would be required to contain the access tokens for each of the roles in a similar JSON object called ``_tokens`` as follows:
+When invoking the flow (e.g. via ``globus-automate flow run``) the flow input would be required to contain the access tokens for each of the roles in a similar JSON object called ``_tokens`` as follows:
 
 .. code-block:: JSON
 
@@ -325,7 +325,7 @@ When invoking the Flow (e.g. via ``globus-automate flow run``) the flow input wo
    }
 
 .. note::
-   If the author of a Flow provides an ``input_schema`` for their Flow, the schema should specify that the ``_tokens`` property should be present with this structure. Otherwise, the Flows service will reject the input prior to running the Flow.
+   If the author of a flow provides an ``input_schema`` for their flow, the schema should specify that the ``_tokens`` property should be present with this structure. Otherwise, the Flows service will reject the input prior to running the flow.
 
 The method for generating the required tokens is outside the scope of this document. The approach will use of the `Globus Auth API <https://docs.globus.org/api/auth/>`_ and typically the `Globus SDK <https://globus-sdk-python.readthedocs.io/en/latest/>`_. In particular, the `section on obtaining tokens <https://globus-sdk-python.readthedocs.io/en/latest/tutorial.html#step-3-get-some-access-tokens>`_ is a good starting point.
 
@@ -335,28 +335,28 @@ Action Execution Monitoring
 ``Action`` states will block until the executed action reaches a
 completion state with status value either ``SUCCEEDED`` or ``FAILED``
 or when the ``WaitTime`` duration is reached. Within this time, the
-Flow will periodically poll the Action to determine if it has reached
+flow will periodically poll the action to determine if it has reached
 a completion state.  The interval between polls doubles after each
 poll ("exponential back-off") up to a maximum interval between polls
 of 10 minutes. Thus, detection of the completion will not be
 instantaneous compared to when the action "actually" completes and may
 be delayed up to the maximum poll interval of 10 minutes.
 
-It is important to remember that this delay between an Action's actual
+It is important to remember that this delay between an action's actual
 completion and it being detected by the Flow service can occur. A user
 running a flow may observe or receive another form of notification
-(such as an email from Globus Transfer) that an Action has completed
+(such as an email from Globus Transfer) that an action has completed
 prior to the Flows service polling to discover the same progress has
 occurred. This is an inherent property of the system.
 
 Managing Exceptions
 -------------------
 
-Failures of Action states in the Flow are exposed via Exceptions which, as described above, can be handled via a ``Catch`` property on the Action state. The form of the ``Catch`` is as shown in the example, but the types of exceptions need to be discussed in more detail. There are three forms of exceptions that impact an Action execution:
+Failures of action states in the flow are exposed via Exceptions which, as described above, can be handled via a ``Catch`` property on the action state. The form of the ``Catch`` is as shown in the example, but the types of exceptions need to be discussed in more detail. There are three forms of exceptions that impact an action execution:
 
-* ``ActionUnableToRun``: This exception indicates that the initial attempt to run the Action failed and no action whatsoever was initiated. The output of the exception contains the error structure returned by the Action. This condition will always result in an exception.
+* ``ActionUnableToRun``: This exception indicates that the initial attempt to run the action failed and no action whatsoever was initiated. The output of the exception contains the error structure returned by the action. This condition will always result in an exception.
 
-* ``ActionFailedException``: This indicates that the Action was able initiated but during execution the Action was considered to have failed by the return of an Action status with the value ``FAILED``. This exception will only be raised if the property ``ExceptionOnActionFailure`` is set to true. This allows the Action failure to be handled by checking the result or by causing an exception. Either approach is valid and different users and different use cases may lend themselves to either approach. In either case, the output will contain the same Action status structure a completed action will contain, but the ``status`` value will necessarily be ``FAILED``.
+* ``ActionFailedException``: This indicates that the action was able initiated but during execution the action was considered to have failed by the return of an action status with the value ``FAILED``. This exception will only be raised if the property ``ExceptionOnActionFailure`` is set to true. This allows the action failure to be handled by checking the result or by causing an exception. Either approach is valid and different users and different use cases may lend themselves to either approach. In either case, the output will contain the same action status structure a completed action will contain, but the ``status`` value will necessarily be ``FAILED``.
 
 * ``ActionTimeout``: When the ``WaitTime`` for an ``Action`` state is exceeded, this exception will be raised. The status of the most recent poll of the ``Action`` will be contained within the body of the exception.
 
@@ -364,23 +364,23 @@ Failures of Action states in the Flow are exposed via Exceptions which, as descr
 Pre-Populated Run-time State
 ----------------------------
 
-Basic information about the flow's state and the user invoking the Flow is provided through a "virtual", read-only property available at the JSONPath ``$._context``. This path may be used in a path for a ``Parameters`` value on an Action or Pass state type, or in expressions which are evaluated when generating ``Parameters`` values as described above. This allows the Flow to use these values as necessary for passing into Actions as parameters. As this is a read-only value, the ``_context`` cannot be overwritten by using the path in a ``ResultPath`` on any state. The ``_context`` value is itself an object
+Basic information about the flow's state and the user invoking the flow is provided through a "virtual", read-only property available at the JSONPath ``$._context``. This path may be used in a path for a ``Parameters`` value on an action or Pass state type, or in expressions which are evaluated when generating ``Parameters`` values as described above. This allows the flow to use these values as necessary for passing into actions as parameters. As this is a read-only value, the ``_context`` cannot be overwritten by using the path in a ``ResultPath`` on any state. The ``_context`` value is itself an object
 containing the following properties:
 
 +---------------+-------------------------------------------------------------------------------------+
 | Property name | Description                                                                         |
 +===============+=====================================================================================+
-| flow_id       | The id of the deployed Flow that is executing                                       |
+| flow_id       | The id of the deployed flow that is executing                                       |
 +---------------+-------------------------------------------------------------------------------------+
-| run_id        | The unique id assigned to **this execution** of the Flow                            |
+| run_id        | The unique id assigned to **this execution** of the flow                            |
 +---------------+-------------------------------------------------------------------------------------+
-| username      | The Globus Auth username for the user invoking the Flow                             |
+| username      | The Globus Auth username for the user invoking the flow                             |
 +---------------+-------------------------------------------------------------------------------------+
-| email         | The email address for the user invoking the Flow                                    |
+| email         | The email address for the user invoking the flow                                    |
 +---------------+-------------------------------------------------------------------------------------+
-| user_id       | The Globus Auth user id for the user invoking the Flow (in URN format)              |
+| user_id       | The Globus Auth user id for the user invoking the flow (in URN format)              |
 +---------------+-------------------------------------------------------------------------------------+
-| identities    | A list of all identities associated with the user invoking the Flow (in URN format) |
+| identities    | A list of all identities associated with the user invoking the flow (in URN format) |
 +---------------+-------------------------------------------------------------------------------------+
 | token_info    | A child object containing the fields exp, iat, and nbf (described below)            |
 +---------------+-------------------------------------------------------------------------------------+
@@ -400,9 +400,9 @@ The ``token_info`` fields are defined as follow:
 ``ExpressionEval`` State type
 -----------------------------
 
-The ``Action`` state type provides a method of evaluating expressions to create Parameter values for passing to the action, and the ``Pass`` state, defined in the States Language, provides a means of moving or re-arranging the Flow's run-time state by specifying input Parameters and new locations via the ``ResultPath``. In some cases, the combination of the two capabilities is desired: the ability to compute results for Parameters as in the ``Action`` state and the simple storage of the new values, as in the ``Pass`` state. This is the role of the ``ExpressionEval`` state type. It can be thought of as an ``Action`` without the Action invocation, or a ``Pass`` where ``Parameters`` may contain expressions.
+The ``Action`` state type provides a method of evaluating expressions to create Parameter values for passing to the action, and the ``Pass`` state, defined in the States Language, provides a means of moving or re-arranging the flow's run-time state by specifying input Parameters and new locations via the ``ResultPath``. In some cases, the combination of the two capabilities is desired: the ability to compute results for Parameters as in the ``Action`` state and the simple storage of the new values, as in the ``Pass`` state. This is the role of the ``ExpressionEval`` state type. It can be thought of as an ``Action`` without the action invocation, or a ``Pass`` where ``Parameters`` may contain expressions.
 
-A primary situation in which this state type will be used is when determining a value to be tested in a ``Choice`` state type. The ``Choice`` state type can only read single values from the run-time state of the Flow, so if, for example, a value on which a ``Choice`` condition needs to be applied must be combined from separate parts of the Flow run-time state. The computed value can then be referenced in the ``Variable`` property of the Choice. Another use is to compute a "final" for the Flow to be stored in the state of the Flow and therefore seen in the output of the Flow upon completion.
+A primary situation in which this state type will be used is when determining a value to be tested in a ``Choice`` state type. The ``Choice`` state type can only read single values from the run-time state of the flow, so if, for example, a value on which a ``Choice`` condition needs to be applied must be combined from separate parts of the flow run-time state. The computed value can then be referenced in the ``Variable`` property of the Choice. Another use is to compute a "final" for the flow to be stored in the state of the flow and therefore seen in the output of the flow upon completion.
 
 An example structure for an ``ExpressionEval`` state is as follows:
 
@@ -437,7 +437,7 @@ The `Globus web app`_ supports a JSON schema format in order to make starting fl
 ``globus-collection``
 ^^^^^^^^^^^^^^^^^^^^^
 
-``globus-collection`` as a ``format`` in your ``input_schema`` will signal to the webapp to show a custom input field for searching for and selecting a Globus collection on the Guided tab when starting a Flow.
+``globus-collection`` as a ``format`` in your ``input_schema`` will signal to the webapp to show a custom input field for searching for and selecting a Globus collection on the Guided tab when starting a flow.
 
 This example input schema shows how to configure a basic Transfer flow using this format:
 
@@ -507,7 +507,7 @@ Important notes about the ``globus-collection`` format:
    * If both "id" and "path" are required, the component will display and require both collection and path inputs
    * If only "id" is required, the component will only display the Collection input
    * If only "path" is required, the component will display both inputs but only the path field will be required. The collection input is provided to allow browsing of that collection's directory listing
-* This format is used to provide a UI component for `Globus web app`_ and will not substantively affect Flow usage from the Automate CLI or programmatic access
+* This format is used to provide a UI component for `Globus web app`_ and will not substantively affect flow usage from the Automate CLI or programmatic access
 
 .. _example-flows-details:
 

--- a/docs/source/cli_docs.rst
+++ b/docs/source/cli_docs.rst
@@ -1,7 +1,7 @@
 ``globus-automate``
 ===================
 
-A command-line client for the Globus Flows Service
+A command-line client for the Globus Flows service
 
 By default, this CLI keeps all its config and cached tokens in
 .globus_automate_tokens.json in the user’s home directory.

--- a/docs/source/cli_docs.rst
+++ b/docs/source/cli_docs.rst
@@ -1,7 +1,7 @@
 ``globus-automate``
 ===================
 
-CLI for Globus Automate
+A command-line client for the Globus Flows Service
 
 By default, this CLI keeps all its config and cached tokens in
 .globus_automate_tokens.json in the user’s home directory.
@@ -22,10 +22,9 @@ By default, this CLI keeps all its config and cached tokens in
 
 **Commands**:
 
--  ``action``: Manage Globus Automate Actions
--  ``flow``: Manage Globus Automate Flows
--  ``queue``: Manage Globus Automate Queues
--  ``session``: Manage your session with the Automate Command Line
+-  ``action``: Manage runs (actions)
+-  ``flow``: Manage flows
+-  ``session``: Manage your session with the Automate command line client
 
 ``globus-automate action``
 --------------------------

--- a/docs/source/example_flows.rst
+++ b/docs/source/example_flows.rst
@@ -1,6 +1,6 @@
 Example Flows
 =============
 
-For examples of Flows, input schemas, and inputs see the `examples in the Globus Automate Client repository`_.
+For examples of flows, input schemas, and inputs see the `examples in the Globus Automate Client repository`_.
 
 ..  _examples in the Globus Automate Client repository: https://github.com/globus/globus-automate-client/tree/main/examples/flows

--- a/docs/source/globus_action_providers.rst
+++ b/docs/source/globus_action_providers.rst
@@ -1,11 +1,11 @@
 Globus Action Providers
 =======================
 
-Globus provides and operates a number of ``Action Providers`` which may be
-invoked directly or used within Flows. Below is a brief summary of the ``Action
-Providers`` being operated including specific information on their URLs, scopes,
+Globus provides and operates a number of action providers which may be
+invoked directly or used within flows. Below is a brief summary of the action
+providers being operated including specific information on their URLs, scopes,
 and a summary of their functionality. Specific input specifications are not
-provided as they may be retrieved from the ``Action Provider`` directly via
+provided as they may be retrieved from the action provider directly via
 introspection:
 
 .. code-block:: BASH
@@ -15,11 +15,11 @@ introspection:
 Or simply click on the URL to view the introspection results in a browser.
 
 .. note::
-    When running Globus operated Action Providers the ``action`` subcommands
+    When running Globus operated action providers the ``action`` subcommands
     do not require the use of the ``--action-scope`` option as these Action
     Providers are publicly visible. If interacting with a non-publicly visible
     Provider, all ``action`` subcommands will require the ``--action-scope``
-    option followed with the Action Provider's corresponding scope value.
+    option followed with the action provider's corresponding scope value.
 
 List of Globus Operated Action Providers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ Scope: ``https://auth.globus.org/scopes/actions.globus.org/hello_world``
 
 Synchronous / Asynchronous: Either
 
-The HelloWorld Action Provider is very simple and is primarily intended for
+The *HelloWorld* action provider is very simple and is primarily intended for
 testing and bootstrapping purposes. It can operate in either synchronous or
 asynchronous modes. In the synchronous mode, only a single string is sent in the
 body and the response will return containing a constant value (``"Hello":
@@ -61,7 +61,7 @@ Scope: ``https://auth.globus.org/scopes/actions.globus.org/transfer/transfer``
 
 Synchronous / Asynchronous: Either
 
-The Action Provider "transfer/transfer" uses the `Globus Transfer Task API`_ to
+The *Globus Transfer - Transfer Data* action provider uses the `Globus Transfer Task API`_ to
 perform a transfer of data from one Globus Collection to another. The input
 includes both the source and destination collection ids and file paths
 within the collection where the source file or folder is located and
@@ -102,14 +102,14 @@ Scope: ``https://auth.globus.org/scopes/actions.globus.org/transfer/set_permissi
 
 Synchronous / Asynchronous: Synchronous
 
-The set permission Action Provider uses the `Globus Transfer ACL API`_ to set or
+The *Globus Transfer - Set Permission* action provider uses the `Globus Transfer ACL API`_ to set or
 manage permissions on a folder or file. The body of the request indicates
 whether the permission rule is to be created, updated or deleted using the
 ``operation`` property. For update or delete, the ``rule_id`` of a previously
 created permission rule must also be provided.
 
 As the Globus Transfer API returns a status directly (rather than a
-task identifier), the Action Provider behaves in a synchronous manner,
+task identifier), the action provider behaves in a synchronous manner,
 returning the Transfer API result.
 
 .. literalinclude:: ../../examples/action_bodies/set_permission.json
@@ -133,7 +133,7 @@ Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/tra
 
 Synchronous / Asynchronous: Synchronous
 
-The Globus Transfer ls Action Provider uses the `Globus Transfer Directory API`_
+The *Globus Transfer - List Directory* action provider uses the `Globus Transfer Directory API`_
 to retrieve a listing of contents from an (endpoint, path) pair.
 Although providing a path is optional, the default path used depends
 on endpoint type and it is best to explicitly set a path. This Action
@@ -155,7 +155,7 @@ Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/tra
 
 Synchronous / Asynchronous: Synchronous
 
-The Globus Transfer mkdir Action Provider uses the `Globus Transfer Make Directory API`_
+The *Globus Transfer - Make Directory* action provider uses the `Globus Transfer Make Directory API`_
 to create a new directory on an endpoint. The input is simply the id for endpoint where the directory will be created and the path on the endpoint to the directory to be created.
 
 .. literalinclude:: ../../examples/action_bodies/mkdir.json
@@ -172,7 +172,7 @@ Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/tra
 
 Synchronous / Asynchronous: Synchronous
 
-The Globus Transfer ls Action Provider uses the `Globus Transfer Get Collection API`_
+The *Globus Transfer - Get Collection* action provider uses the `Globus Transfer Get Collection API`_
 to get information about a Globus Collection. The information returned is the same as defined by the Globus Transfer API with one addition: a property ``is_managed``. When ``true``, the ``is_managed`` property indicates that a collection (or its host) is managed under a Globus subscription.
 
 
@@ -186,16 +186,16 @@ Scope: ``https://auth.globus.org/scopes/actions.globus.org/search/ingest``
 Synchronous / Asynchronous: Asynchronous
 
 Records may be added to an existing `Globus Search
-<https://docs.globus.org/api/search/>`_ index using the Search /
-ingest Action Provider. The input to the Action Provider includes the
+<https://docs.globus.org/api/search/>`_ index using the *Globus Search -
+Ingest* action provider. The input to the action provider includes the
 id of the Search index to be added to and the data, in the
 Search-defined ``GMetaEntry`` format. The user calling the Action
 Provider must have permission to write to the index referenced. Globus
 Search will process the ingest operation asynchronously, so this
-Action Provider also behaves in an asynchronous fashion: requests to
+action provider also behaves in an asynchronous fashion: requests to
 update the state of an Action will reflect the result from updating
 the state of the ingest task in Globus Search. Since Globus Search
-does not support cancellation of tasks, this Action Provider also does
+does not support cancellation of tasks, this action provider also does
 not support cancellation of its Actions.
 
 .. literalinclude:: ../../examples/action_bodies/search_ingest.json
@@ -212,20 +212,20 @@ Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/sea
 Synchronous / Asynchronous: Asynchronous
 
 Subjects or entries may be removed from an existing `Globus Search
-<https://docs.globus.org/api/search/>`_ index using the Search
-Delete Action Provider. The input to the Action Provider includes the
+<https://docs.globus.org/api/search/>`_ index using the *Globus Search -
+Delete* action provider. The input to the action provider includes the
 Search index id to delete the data from. The body also specifies the type of
 delete operation to execute via the ``delete_by`` parameter. It's value may be
 ``entry`` to delete a single entry, ``subject`` to delete a subject, or
 ``query`` to remove data matching a `Search query
 <https://docs.globus.org/api/search/entry_and_subject_ops/#delete_by_query>`_.
 
-The user calling the Action Provider must have permission to write to the index
+The user calling the action provider must have permission to write to the index
 referenced. Globus Search will process the delete operation asynchronously, so
-this Action Provider also behaves in an asynchronous fashion. Requests for the
+this action provider also behaves in an asynchronous fashion. Requests for the
 state of an Action will lookup the state of the ``task_id`` in Globus Search,
 ensuring the status remains up-to-date. Since Globus Search does not support
-cancellation of tasks, this Action Provider also does not support cancellation
+cancellation of tasks, this action provider also does not support cancellation
 of its Actions.
 
 .. literalinclude:: ../../examples/action_bodies/search_delete_by_subject.json
@@ -245,7 +245,7 @@ Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/not
 
 Synchronous / Asynchronous: Synchronous
 
-The Send notification / email Action Provider presently supports sending of
+The *Send Notification / Email* action provider presently supports sending of
 email messages to a set of email addresses. The request to send the email
 contains the standard components of an email: sender, receiver(s), subject and
 body. The mimetype of the body may be specified so that either HTML or text
@@ -262,7 +262,7 @@ sending email are supported: SMTP and AWS SES. When SMTP is provided, the
 username, password and server hostname are required. When AWS SES is provided,
 the AWS access key, AWS access key secret and the AWS region must be provided.
 As this service is synchronous and stateless, the requester can be assured that
-these credentials will not be stored. The Action Provider will return success as
+these credentials will not be stored. The action provider will return success as
 long as the email service accepts the message. It cannot guarantee successful
 delivery of the message including an inability to deliver the message due to an
 improper recipient address.
@@ -285,8 +285,8 @@ Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/web
 Synchronous / Asynchronous: Asynchronous
 
 Flows or other clients which desire to provide users a method of selecting an
-option from a fixed set may use the Wait for User Option Selection Action
-Provider. The Action Provider can operate in one of two modes.
+option from a fixed set may use the *Wait for User Option Selection Action
+Provider*. The action provider can operate in one of two modes.
 
 In the first mode, a list of options are created which are automatically
 selected by any access to a corresponding URLs. For each option, a name, a URL
@@ -299,7 +299,7 @@ by the input to the Action and the Action will transition to a ``SUCCEEDED``
 status. Each of the options may be protected for access only via specific Globus
 identities by setting values on the ``selectable_by`` list. A direct HTTP access
 may present a Bearer token for authorization using the same scope as used for
-accessing the other operations on the Action Provider. If no access token is
+accessing the other operations on the action provider. If no access token is
 presented, the user will be re-directed to start an OAuth Flow using Globus Auth
 to authenticate access to the option URL.
 
@@ -321,7 +321,7 @@ but not on any of the individual options, the options inherit the same
 
 In either mode, once an option has been selected, none of the url suffixes, nor
 the landing page if configured, in the initial request, will be responded to by
-the Action Provider: they will return the HTTP not found (error) status 404.
+the action provider: they will return the HTTP not found (error) status 404.
 Upon completion, the body of the status will include the name and the url suffix
 for the selected option. The body may also include input on the HTTP data passed
 when the option's URL was accessed including the query parameters and the body.
@@ -343,9 +343,9 @@ Simple Expression Evaluation
 ----------------------------
 
 .. note::
-    Expression Evaluation has been integrated with Action definitions directly
+    Expression evaluation has been integrated with action definitions directly
     (see section :ref:`flow_action_expressions`). Thus, for most use cases, the
-    Simple Expression Evaluation Action Provider described here is not needed
+    *Simple Expression Evaluation* action provider described here is not needed
     and expressions defined on Action definitions within a Flow are preferred.
 
 URL: `<https://actions.globus.org/expression_eval>`_
@@ -356,7 +356,7 @@ Synchronous / Asynchronous: Synchronous
 
 Evaluation of simple expressions is supported using the `simpleeval
 <https://github.com/danthedeckie/simpleeval>`_ library and therefore syntax. A
-single invocation of the Action Provider may evaluate a single expression or
+single invocation of the action provider may evaluate a single expression or
 multiple expressions. An Expression request consists of up to three parts:
 
 * | An ``expression`` (required) which is a basic "arithmetic" type expression.
@@ -393,7 +393,7 @@ Scope: ``https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/dat
 
 Synchronous / Asynchronous: Synchronous
 
-The Datacite DOI Minting action provider uses the `Datacite JSON API
+The *Datacite DOI Minting* action provider uses the `Datacite JSON API
 <https://support.datacite.org/docs/api-create-dois>`_ to mint DOIs. The main
 part of the body input is as specified in that API. The additional fields
 provide the username and password (the "Basic Auth" credentials which is part of
@@ -415,7 +415,7 @@ Scope: ``https://auth.globus.org/scopes/b3db7e59-a6f1-4947-95c2-59d6b7a70f8c/act
 Synchronous / Asynchronous: Asynchronous
 
 FuncX supports an asynchronous action provider to provide access via the Globus
-Automate ecosystem. More details can be found `in the funcX documentation
+automation platform. More details can be found `in the funcX documentation
 <https://funcx.readthedocs.io/en/latest/actionprovider.html>`_.
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,9 +1,8 @@
 Globus Automate - CLI and Python SDK
 ====================================
 
-This is the command line interface and Python package
-for working with Globus Automate, primarily Globus Flows, any service
-implementing the Globus Action Provider Interface, and Globus Queues.
+This is the command line interface and Python package for working with the Globus
+Flows service and services that implement the Globus Action Provider interface.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -73,7 +73,7 @@ identities are allowed to read or modify the action's state. *Globus Flows*
 allows orchestrating these individual actions into robust
 processes that can tolerate their distinct execution states, including success
 and failure. Users will not often need to operate on actions directly,
-rather, the User will create a run of a flow and the run will invoke
+rather, the User will start a run of a flow and the run will invoke
 action providers, creating actions as necessary to accomplish the
 automation.
 
@@ -100,7 +100,7 @@ by other flows by its flow URL. This allows for modularity in defining
 flows and in a separation of concerns where "sub-flows" can be trusted to
 provide some process or behavior.
 
-When users execute flow, we call that a *run*. A
+When users start a flow, we call that a *run*. A
 run shares the action interface, supporting operations such as viewing
 its status, cancelling its execution, and removing its execution state. This
 allows for common tooling and terminology for working with runs and

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -58,7 +58,7 @@ SDK that makes it easy to provide custom services that can be tied
 into the Globus automation ecosystem.
 
 These action providers form the foundation of the Globus automation ecosystem
-and are primarily used by referencing their URLs in `Flows`_.
+and are primarily used by referencing their URLs in `flows`_.
 *Globus Flows* allows users to flexibly piece together these individual
 services to create reliable high level workflows.
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -1,23 +1,22 @@
-Globus Automate Overview
-========================
+Globus Automation Overview
+==========================
 
-The Globus Automate platform provides tools and services which can be used to
-create reliable processes for research data management. The platform builds on the
-foundation of Globus capabilities such as Authorization and Data Transfer.
+The Globus automation platform provides tools and services which can be used to
+create reliable, easily-repeatable processes for research data management.
+The platform builds on key Globus services like Authorization and Data Transfer.
 
-The
-Automate Platform introduces a few key concepts which may then be extended and
+The automation platform introduces a few key concepts which may then be extended and
 combined to create custom processes solving particular research data management
-problems. These concepts are ``Action Providers``, ``Actions``, and ``Flows``.
-Read on to learn about how ``Flows`` orchestrate ``Action Providers`` together
-in order to create ``Actions`` that perform the actual automation.
+problems. These concepts are *action providers*, *actions*, and *flows*.
+Read on to learn about how flows can orchestrate action providers together
+in order to create actions that perform the actual automation.
 
 Use Cases
 ---------
 
 The key to the platform is enabling users to orchestrate multiple processing
-steps into a single workflow, or ``Flow``. Some of these steps are provided by
-``Globus Automate`` and others of which may be custom implementations supporting
+steps into a single workflow, or *flow*. Some of these steps are provided by
+Globus and others of which may be custom implementations supporting
 a specific need. Examples of these workflows might be:
 
 - Automatically detect data output from scientific instruments which is then
@@ -30,52 +29,52 @@ a specific need. Examples of these workflows might be:
 Action Providers
 ----------------
 
-An ``Action Provider`` is an HTTP accessible service which acts as a single step
-in a process and implements the ``Action Provider Interface``. When
-an ``Action Provider`` is invoked, it creates (or "provides") an ``Action``
+An *action provider* is an HTTP accessible service which acts as a single step
+in a process and implements the action provider interface. When
+an action provider is invoked, it creates (or "provides") an action
 which represents a single unit of work. Examples of units of work are running a
-file transfer using ``Globus Transfer`` or ingesting data into ``Globus
-Search``.
+file transfer using *Globus Transfer* or ingesting data into *Globus
+Search*.
 
-Each ``Action Provider`` expects to be invoked with parameters
+Each action provider expects to be invoked with parameters
 particular to the service it provides. To support usability and discovery, each
 can be introspected to determine what its ``input schema`` or input properties
-are. Introspection also provides information such as who operates the ``Action
-Provider``, descriptive text on the service it provides, and who can use the
-service. Access to ``Action Providers`` and their invocation is controlled via
-``Globus Auth``. Some of these services may be *synchronous* meaning that an
+are. Introspection also provides information such as who operates the action
+provider, descriptive text on the service it provides, and who can use the
+service. Access to action providers and their invocation is controlled via
+*Globus Auth*. Some of these services may be *synchronous* meaning that an
 invocation will complete in the context of the HTTP request that triggered it.
 Other services support *asynchronous* activities, meaning that the invocation
 will persist beyond the HTTP request that invoked it and the caller must
-monitor the ``Action`` for updates on when it is completed and its result.
+monitor the action for updates on when it is completed and its result.
 
-Globus operates a series of these ``Action Providers`` available for
-public use.  For a full list of these ``Action Providers``, see
+Globus operates a series of these action providers available for
+public use.  For a full list of these action providers, see
 `section Globus Action Providers
 <globus_action_providers.html>`_. Globus also supports users writing
-their own ``Action Providers`` via the `Globus Action Provider Toolkit
+their own action providers via the `Globus Action Provider Toolkit
 <https://action-provider-tools.readthedocs.io/en/latest/>`_ - a Python
 SDK that makes it easy to provide custom services that can be tied
-into the ``Globus Automate`` ecosystem of services.
+into the Globus automation ecosystem.
 
-These ``Action Providers`` form the foundation of  ``Globus Automate`` and are
-primarily used by referencing their URLs in `Flows`_.
-``Globus Automate`` allows users to flexibly piece together these individual
+These action providers form the foundation of the Globus automation ecosystem
+and are primarily used by referencing their URLs in `Flows`_.
+*Globus Flows* allows users to flexibly piece together these individual
 services to create reliable high level workflows.
 
 
 Actions
 -------
 
-An ``Action`` represents a single, discrete invocation of an ``Action
-Provider``. It is record of an operation and includes details for its result,
-its current execution status, and metadata dictating which ``Globus Auth``
-identities are allowed to read or modify the ``Action``'s state. ``Globus
-Automate`` services allow orchestrating these individual ``Actions`` into robust
+An *action* represents a single, discrete invocation of an action
+provider. It is record of an operation and includes details for its result,
+its current execution status, and metadata dictating which *Globus Auth*
+identities are allowed to read or modify the action's state. *Globus Flows*
+allows orchestrating these individual actions into robust
 processes that can tolerate their distinct execution states, including success
-and failure. Users will not often need to operate on ``Actions`` directly,
-rather, the User will create a ``Run`` of a ``Flow`` and the ``Run`` will invoke
-``Action Providers``, creating ``Actions`` as necessary to accomplish the
+and failure. Users will not often need to operate on actions directly,
+rather, the User will create a run of a flow and the run will invoke
+action providers, creating actions as necessary to accomplish the
 automation.
 
 
@@ -84,50 +83,48 @@ automation.
 Flows
 -----
 
-A ``Flow`` represents a single process that orchestrates a series of services
-into a self contained operation. One can think of a ``Flow`` as a
-declaratively defined ordering of ``Action Providers`` with condition handling
+A *flow* represents a single process that orchestrates a series of services
+into a self contained operation. One can think of a flow as a
+declaratively defined ordering of action providers with condition handling
 to define expected success or failure scenarios.
 
-A ``Flow`` may be defined and deployed to the ``Flows`` service by any user.
-When deploying, the user may control which other users can discover the ``Flow``
-and separately, which users can run the ``Flow``. All access control is provided
-by ``Globus Auth``. Thus, ``Flows`` can easily and safely be shared among users.
-Once deployed, the ``Flow`` will receive a HTTP-accessible ``Flow`` URL which
-makes it available for use in ``Globus Automate``.
+A flow may be defined and deployed to the *Globus Flows* service by any user.
+When deploying, the user may control which other users can discover the flow
+and separately, which users can run the flow. All access control is provided
+by *Globus Auth*. Thus, flows can easily and safely be shared among users.
 
-It may also be interesting to note that once deployed, the ``Flow`` will
-implement the ``Action Provider Interface``. What this means is that a ``Flow``
-is technically a form of ``Action Provider``, and as such it can be referenced
-by other ``Flows`` by its ``Flow`` URL. This allows for modularity in defining
-``Flows`` and in a separation of concerns where ``SubFlows`` can be trusted to
+It may also be interesting to note that once deployed, the flow will
+implement the action provider interface. What this means is that a flow
+is technically a form of action provider, and as such it can be referenced
+by other flows by its flow URL. This allows for modularity in defining
+flows and in a separation of concerns where "sub-flows" can be trusted to
 provide some process or behavior.
 
-When users run an instance of the ``Flow``, we call that a ``Run``. A
-``Run`` shares the ``Action`` interface, supporting operations such as viewing
+When users execute flow, we call that a *run*. A
+run shares the action interface, supporting operations such as viewing
 its status, cancelling its execution, and removing its execution state. This
-allows for common tooling and terminology for working with ``Runs`` and
-``Actions``.  In general, any operation available on an ``Action`` will be
-possible on a ``Run`` and vice versa.
+allows for common tooling and terminology for working with runs and
+actions.  In general, any operation available on an action will be
+possible on a run and vice versa.
 
-``Globus Automate`` imposes no restrictions on how long a ``Run`` may execute or
-on the number of units of work defined in a ``Flow``. We support long running
-``Runs`` by providing support for monitoring and status updates.
+*Globus Flows* imposes no restrictions on how long a run may execute or
+on the number of units of work defined in a flow. We support long-lived
+runs by providing monitoring and status updates.
 
 Authentication and Authorization
 --------------------------------
 
-An important consideration in the ``Globus Automate`` platform is authentication
-and authorization. All interactions with ``Action Providers`` ``Actions`` and
-``Flows`` are authenticated by ``Globus Auth``.
+An important consideration in the Globus automation platform is authentication
+and authorization. All interactions with action providers, actions, and
+flows are authenticated by *Globus Auth*.
 
-For ``Action Providers`` and ``Flows``, authorization lists exist to control
+For action providers and flows, authorization lists exist to control
 which identities can view its details and which identities can invoke an
-``Action`` or ``Run`` of a Flow in the service. For ``Actions`` and ``Runs``,
+action or run of a Flow in the service. For actions and runs,
 authorization lists exist to enforce which identities may view its execution
 details and which identities may modify the execution status. For these
 authorization lists, identities may be specified as individual Globus users or
-as Globus Groups. Thus, while the ``Globus Automate`` platform is open to all
+as Globus Groups. Thus, while the Globus automation platform is open to all
 users with access, it is possible to carefully control which users have access
 to your resources.
 
@@ -149,7 +146,7 @@ Once a Flow has been started, a "run" object is created for monitoring and manag
 
 - ``run_owner``: This is the user who initiated the run of the Flow. Unlike a ``flow_owner`` this role cannot be transferred to another user. The ``run_owner`` can perform the same operations as a user in the ``run_managers`` list.
 
-For both Flows and Flow runs, the authorization lists are "cumulative"
+For both flows and runs, the authorization lists are "cumulative"
 in the sense that a user in a particular list (termed having that
 "role") may also perform all the operations of users in the roles
 listed prior to it in the list. Thus, for example, a user in the

--- a/docs/source/python_sdk_reference.rst
+++ b/docs/source/python_sdk_reference.rst
@@ -4,8 +4,8 @@ Python SDK Reference
 ====================
 
 The Globus Automate Client package provides a Python SDK for interfacing with
-and invoking Globus Actions and Flows. Below, we provide information on helper
-functions available for creating authenticated Action and
+and invoking Globus actions and flows. Below, we provide information on helper
+functions available for creating authenticated action and
 Flow clients as well as documentation on the methods available to those clients.
 
 Actions Client
@@ -31,7 +31,7 @@ create authenticated ``ActionClient`` and ``FlowsClient`` instances. These
 helpers share functionality with the ``globus-automate`` CLI to handle loading
 and storing ``Globus Auth`` tokens on the local filesystem. They will also
 trigger interactive logins when additional consents are required to interact
-with ``Actions`` or ``Flows``.
+with actions or flows.
 
 .. autofunction:: globus_automate_client.create_action_client
 

--- a/docs/source/python_sdk_reference.rst
+++ b/docs/source/python_sdk_reference.rst
@@ -6,7 +6,7 @@ Python SDK Reference
 The Globus Automate Client package provides a Python SDK for interfacing with
 and invoking Globus actions and flows. Below, we provide information on helper
 functions available for creating authenticated action and
-Flow clients as well as documentation on the methods available to those clients.
+flow clients as well as documentation on the methods available to those clients.
 
 Actions Client
 ^^^^^^^^^^^^^^

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -7,19 +7,19 @@ Installation
 ------------
 
 The Globus Automate CLI and SDK contains both a command-line tool
-``globus-automate`` and a client library for interacting with Actions and Flows.
+``globus-automate`` and a client library for interacting with actions and flows.
 It requires `Python <https://www.python.org/>`_ 3.6+. If a supported version of
 Python is not already installed on your system, see this `Python installation guide
 <https://docs.python-guide.org/starting/installation/>`_.
 
 For new users and users who want to primarily use the CLI interface into
-``Globus Automate``, we highly recommend installing the package using pipx_:
+*Globus Flows*, we highly recommend installing the package using pipx_:
 
 .. code-block:: bash
 
     pipx install globus-automate-client
 
-For users interested in programmatic access to ``Globus Automate``, the SDK
+For users interested in programmatic access to *Globus Flows*, the SDK
 interface will be required. Simply install the ``globus-automate-client``
 library using your choice of package manager. For example, if using the `pip
 package manager <https://pypi.python.org/pypi/pip>`_:
@@ -39,7 +39,7 @@ functionality:
     globus-automate --help
 
 
-Or, if programmatic access to the Flows service is required, simply import the
+Or, if programmatic access to the *Flows* service is required, simply import the
 SDK in a Python script:
 
 .. code-block:: python
@@ -49,14 +49,14 @@ SDK in a Python script:
 
 .. note::
     Most operations available on the CLI are also available in the SDK. For
-    users getting familiar with the Automate service, we recommend starting off
+    users getting familiar with the *Flows* service, we recommend starting off
     with the CLI interface.
 
 
 Authentication
 --------------
 
-All CLI and SDK operations invoking Globus Automate services require
+All CLI and SDK operations invoking Globus automation services require
 authentication.
 
 When using the SDK, all operations require that authentication be provided in
@@ -64,7 +64,7 @@ the form of `Globus Authorizers
 <https://globus-sdk-python.readthedocs.io/en/stable/authorization.html>`_.
 
 
-Upon first interaction with any Globus Automate service via the CLI, a
+Upon first interaction with any Globus automation service via the CLI, a
 text prompt will appear directing the user to a web URL where they can proceed
 through an authentication process using Globus Auth to consent to the service
 they are using the CLI to interact with. This typically only needs to be done
@@ -91,19 +91,5 @@ Or, to invalidate the authentication cache's contents first and then remove it:
 .. note::
     These commands will remove locally cached authentication data for all Globus
     Automate services.
-
-Example Flows
--------------
-
-To get started with authoring flows, you may find it helpful to reference some
-examples. The following flows are publicly visible and demonstrate some simple
-and common operations you may want to copy into your own flows:
-
-- :ref:`example-flow-move` (flow ID ``9123c20b-61e0-46e8-9469-92c999b6b8f2`` at
-  the time of writing).
-- :ref:`example-flow-2-stage-transfer` (flow ID
-  ``79a4653f-f8da-43b6-a581-5d3b345ad575``).
-- :ref:`example-flow-transfer-set-permissions` (flow ID
-  ``cdcd6d1a-b1c3-4e0b-8d4c-f205c16bf80c``).
 
 .. _pipx: https://pipxproject.github.io/pipx/installation/

--- a/docs/source/using_the_cli.rst
+++ b/docs/source/using_the_cli.rst
@@ -1,7 +1,7 @@
 Using the CLI
 =============
 
-For many, the primary way of interacting with Globus Automate services will be
+For many, the primary way of interacting with Globus automation services will be
 via the CLI.
 
 Configuration
@@ -58,7 +58,7 @@ makes use of JSON, it can be specified in one of two ways:
 
     where ``--option`` is the option requiring a JSON formatted parameter.
 
-Commands which can run or monitor an Action or Flow Run support a ``--watch``
+Commands which can run or monitor an action or run support a ``--watch``
 flag which can be used to stream updates on an activity's execution state.
 
 Many operations require a principal ID to delegate access. This value represents
@@ -69,30 +69,30 @@ user, or ``urn:globus:groups:id:`` if it is a Group.
 Using the CLI with Actions
 --------------------------
 
-In Globus Automate, Actions represent a single unit of work. Actions are created
-by invoking ``Action Providers``. The CLI provides a means of interacting with
-``Action Providers`` to create and manage Actions, however in many cases, the
-fine grain nature of the Actions means they are not often interacted with
+In Globus automation services, *actions* represent a single unit of work. Actions
+are created by invoking *action providers*. The CLI provides a means of interacting
+with action providers to create and manage actions, however in many cases, the
+fine grain nature of the actions means they are not often interacted with
 directly.
 
-To interact with an Action, you must know the URL for the ``Action Provider``
+To interact with an action, you must know the URL for the action provider
 that created (or will create) it. This URL is specified using the
 ``--action-url`` option to the ``action`` subcommands.
 
 Wherever an ``--action-url`` option is present, the ``--action-scope`` option
 may also be provided. The *scope string* is the Globus Auth scope registered for
-interacting with this Action Provider. This *scope string* is published as part
-of the ``Action Provider``'s description (see
+interacting with this action provider. This *scope string* is published as part
+of the action provider's description (see
 :ref:`Introspection`) and the CLI will automatically retrieve
 this value when it is not specified by the user. In some cases, even retrieving
 the *scope string* may require authentication, and in these cases, introspecting
-the ``Action Provider`` is not possible  without providing the
+the action provider is not possible  without providing the
 ``--action-scope`` option.
 
-All of the ``Action Providers`` operated by the Globus team are described in the
+All of the action providers operated by the Globus team are described in the
 section :doc:`globus_action_providers`, which includes their URL and
-tips on using the CLI for interactions with these ``Action Providers`` directly.
-As these ``Action Providers`` are publicly viewable, there is no need to provide
+tips on using the CLI for interactions with these action providers directly.
+As these action providers are publicly viewable, there is no need to provide
 the  ``--action-scope`` option when working with them from the CLI -- the CLI
 will look up the *scope string* automatically.
 
@@ -105,8 +105,8 @@ Provider`` at the URL ``https://actions.globus.org/hello_world``.
 Introspection
 ^^^^^^^^^^^^^
 
-The first step to learning more about an ``Action Provider`` is using the
-introspect operation to get a description of the ``Action Provider``:
+The first step to learning more about an action provider is using the
+introspect operation to get a description of the action provider:
 
 .. code-block:: BASH
 
@@ -147,7 +147,7 @@ introspect operation to get a description of the ``Action Provider``:
         "runnable_by": [
             "all_authenticated_users"
         ],
-        "subtitle": "An Action responding Hello to an input value",
+        "subtitle": "An action responding Hello to an input value",
         "synchronous": false,
         "title": "Hello World",
         "types": [
@@ -163,29 +163,29 @@ introspect operation to get a description of the ``Action Provider``:
     </details>
 
 From this introspection response we can see that the *scope string* for
-this ``Action Provider`` is the value of the ``globus_auth_scope`` field,
+this action provider is the value of the ``globus_auth_scope`` field,
 ``https://auth.globus.org/scopes/actions.globus.org/hello_world``. We
 can also see that the ``admin_contact`` is Globus.
 
-For information on what this ``Action Provider`` does, it is useful to examine
+For information on what this action provider does, it is useful to examine
 the ``title``, ``subtitle``, and ``description`` fields. We can also see that
-the ``Action Provider`` is ``visible_to`` *public*, meaning that anyone can make
+the action provider is ``visible_to`` *public*, meaning that anyone can make
 unauthenticated requests to the introspection endpoint. Similarly, it is
 ``runnable_by`` *all_authenticated_users*, meaning that any user with valid
-Globus Auth credentials may use this ``Action Provider`` to create Actions.
+Globus Auth credentials may use this action provider to create actions.
 
 The most important information for our next step is the ``input_schema`` element
-as it provides a description of the input we need to form for running an Action
-on this ``Action Provider``. The ``input_schema`` element is in `JSON Schema
+as it provides a description of the input we need to form for running an action
+on this action provider. The ``input_schema`` element is in `JSON Schema
 <https://https://json-schema.org/>`_ format. This schema defines three properties:
 ``echo_string``, ``sleep_time``, and ``required_dependent_scope``. We will use
-this information in the next section on running an Action.
+this information in the next section on running an action.
 
 Running
 ^^^^^^^
 
-The first step to prepare for running an Action is to create a file containing
-the input to the Action. We'll call the file ``hello_input.json`` and it
+The first step to prepare for running an action is to create a file containing
+the input to the action. We'll call the file ``hello_input.json`` and it
 contains the following:
 
 .. code-block:: JSON
@@ -196,11 +196,11 @@ contains the following:
   }
 
 This input conforms to the ``input_schema`` from the :ref:`Introspection` call,
-and  specifies that we will have the Action echo a message back to us and that it
-will "sleep" for 60 seconds until the Action is complete. We'll use this sleep
-time to demonstrate monitoring the state of an Action below.
+and  specifies that we will have the action echo a message back to us and that it
+will "sleep" for 60 seconds until the action is complete. We'll use this sleep
+time to demonstrate monitoring the state of an action below.
 
-With our input in place, run the Action using the following command:
+With our input in place, run the action using the following command:
 
 .. code-block:: BASH
 
@@ -210,8 +210,8 @@ With our input in place, run the Action using the following command:
 
     If this is your first time running the ``Hello World Action Provider`` you
     will see text and a prompt appear on your terminal window. Follow the
-    instructions to authenticate to Globus Auth to run this Action. This will
-    only appear on the first time you interact with an ``Action Provider``.
+    instructions to authenticate to Globus Auth to run this action. This will
+    only appear on the first time you interact with an action provider.
 
 
 The resulting output will look like:
@@ -243,54 +243,54 @@ The resulting output will look like:
 
 
 This output is referred to as an ``Action Status`` document and all output from
-working with Actions will follow this format.
+working with actions will follow this format.
 
-The ``action_id`` is an identifier associated with this ``Action Provider``
-invocation and is used to track this Action's lifecycle.
+The ``action_id`` is an identifier associated with this action provider
+invocation and is used to track this action's lifecycle.
 
-The ``status`` value of ``ACTIVE`` indicates that the Action is in the process
+The ``status`` value of ``ACTIVE`` indicates that the action is in the process
 of executing. The possible values for ``status`` are:
 
 - ``ACTIVE``
-    The Action is running and making progress towards completion.
+    The action is running and making progress towards completion.
 - ``INACTIVE``
-    The Action has not yet completed and it is not making
+    The action has not yet completed and it is not making
     progress.  Commonly, some intervention is necessary to help it continue to
     make progress.
 - ``SUCCEEDED``
-    The Action is complete and the completion was considered to be normal.
+    The action is complete and the completion was considered to be normal.
 - ``FAILED``
-    The Action has stopped running due to some error condition. It cannot make
+    The action has stopped running due to some error condition. It cannot make
     progress towards a successful completion.
 
-Each Action can be provided a ``label`` to help identity the purpose for which
+Each action can be provided a ``label`` to help identity the purpose for which
 it was run.
 
-The ``details`` field format is specific to every ``Action Provider`` and is the
-output or result of running the Action. It will often contain information about
-why an Action has reached the state it is in.
+The ``details`` field format is specific to every action provider and is the
+output or result of running the action. It will often contain information about
+why an action has reached the state it is in.
 
 The ``release_after`` field is an ISO8601 format time duration value that
-indicates how long after completion the ``Action Provider`` will retain a record
-of the Action's execution. Until then, the record will persist and can be looked
+indicates how long after completion the action provider will retain a record
+of the action's execution. Until then, the record will persist and can be looked
 up.
 
-``monitor_by`` represents delegated read-only access to the Action's execution
-state, meaning that principals in an Action's ``monitor_by`` field will be able
-to retrieve the Action's execution state (see :ref:`Retrieving Status`).
+``monitor_by`` represents delegated read-only access to the action's execution
+state, meaning that principals in an action's ``monitor_by`` field will be able
+to retrieve the action's execution state (see :ref:`Retrieving Status`).
 Principals may be either a Globus Auth user or a Globus Auth group. The format
 for a Globus Auth user is ``urn:globus:auth:identity:<UUID>`` and for a Globus
 Auth group is ``urn:globus:groups:id:<UUID>``.
 
-``manage_by`` represents delegated write access to the Action's execution state,
-meaning that principals in an Action's ``manage_by`` field will have the ability
+``manage_by`` represents delegated write access to the action's execution state,
+meaning that principals in an action's ``manage_by`` field will have the ability
 to change the alter the state it is in (see :ref:`Canceling and Releasing`).
 Principals may be either a Globus Auth user or a Globus Auth group. The format
 for a Globus Auth user is ``urn:globus:auth:identity:<UUID>`` and for a Globus
 Auth group is ``urn:globus:groups:id:<UUID>``.
 
-Since the Action has already been run, we cannot change any of these fields. If
-we wanted to run another Action with updated values for any of the fields, we
+Since the action has already been run, we cannot change any of these fields. If
+we wanted to run another action with updated values for any of the fields, we
 would pass those as command line options. For information on how to use the
 options, run the command with ``--help``:
 
@@ -303,7 +303,7 @@ options, run the command with ``--help``:
 
     You can specify each of the ``--monitor-by`` and ``--manage-by`` flags
     multiple times to provide multiple principals with read or write access on
-    the Action.
+    the action.
 
 
 ..  _Retrieving Status:
@@ -311,21 +311,21 @@ options, run the command with ``--help``:
 Retrieving Status
 ^^^^^^^^^^^^^^^^^
 
-Once an Action has been run, the user who initiated the Action or anyone in
-the Action's ``monitor_by`` field can monitor or retrieve its status as follows:
+Once an action has been run, the user who initiated the action or anyone in
+the action's ``monitor_by`` field can monitor or retrieve its status as follows:
 
 .. code-block:: BASH
 
     globus-automate action status --action-url https://actions.globus.org/hello_world <action_id>
 
 where the ``action_id`` is the value returned from the ``action run`` command
-from above. The output will be an Action Status document. When the Action is
+from above. The output will be an Action Status document. When the action is
 completed, the ``completion_time`` field will be present indicating when the
-Action reached its final state. You can continue requesting the Action's status
-as long as the Action exists on the ``Action Provider``.
+action reached its final state. You can continue requesting the action's status
+as long as the action exists on the action provider.
 
-In out example, we asked the Action to "sleep" for 60 seconds. Therefore, the
-Action will remain in an ``ACTIVE`` state until 60 seconds have passed, at which
+In out example, we asked the action to "sleep" for 60 seconds. Therefore, the
+action will remain in an ``ACTIVE`` state until 60 seconds have passed, at which
 point the status should be ``SUCCEEDED``.
 
 
@@ -334,121 +334,121 @@ point the status should be ``SUCCEEDED``.
 Canceling and Releasing
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-An Action which is running, but which is no longer needed, may be canceled (or
-released) by the user who initiated the Action execution or anyone in the
-Action's ``manage_by`` field using a command of the form:
+An action which is running, but which is no longer needed, may be canceled (or
+released) by the user who initiated the action execution or anyone in the
+action's ``manage_by`` field using a command of the form:
 
 .. code-block:: BASH
 
     globus-automate action cancel --action-url https://actions.globus.org/hello_world <action_id>
 
 The cancel operation is considered to be an advisory request from the user.
-Actions may not be cancelled immediately, or they may not be canceled at all. A
-request to cancel an Action which has reached a final state of either
+actions may not be cancelled immediately, or they may not be canceled at all. A
+request to cancel an action which has reached a final state of either
 ``SUCCEEDED`` or ``FAILED`` will result in an error return.
 
-To remove an Action's state from the ``Action Provider``, the user who initiated
-the Action execution or anyone in the Action's ``manage_by`` field can use the
+To remove an action's state from the action provider, the user who initiated
+the action execution or anyone in the action's ``manage_by`` field can use the
 release subcommand:
 
 .. code-block:: BASH
 
     globus-automate action release --action-url https://actions.globus.org/hello_world <action_id>
 
-Release may only be performed on Actions which have reached a final state. If
-the Action is in either the ``ACTIVE`` or ``INACTIVE`` state, the release will
+Release may only be performed on actions which have reached a final state. If
+the action is in either the ``ACTIVE`` or ``INACTIVE`` state, the release will
 fail.
 
-Once released, the Action state is forever removed from the ``Action Provider``
-and all attempts to access it will fail. ``Action Providers`` use the
+Once released, the action state is forever removed from the action provider
+and all attempts to access it will fail. Action providers use the
 ``maximum_deadline`` field to advertise how long they will keep a record of an
-Action after it reaches a completed state. The time at which this will happen is
+action after it reaches a completed state. The time at which this will happen is
 equal to the ``completion_time`` plus the ``release_after`` values in the Action
 Status document.
 
 Using the CLI with Flows
 ------------------------
 
-As described in the section on :ref:`Flows`, a Flow combines Actions and
-other operations into a more complex operation. When a Flow is invoked, it
-creates a ``Run`` and the ``Run``'s interface is very much like an Action's; it
+As described in the section on :ref:`Flows`, a *flow* combines actions and
+other operations into a more complex operation. When a flow is invoked, it
+creates a *run* and the run's interface is very much like an action's; it
 has ``run``, ``status``, ``cancel`` and ``release`` operations defined. Because
-of this similarity, we sometimes refer to ``Run``'s as Actions in the
+of this similarity, we sometimes refer to runs as actions in the
 documentation, CLI and SDK.
 
-The CLI contains commands for creating, defining, and managing Flows definition
-and commands for running, monitoring, and managing Flow ``Runs`` (also known as
-``Actions``).
+The CLI contains commands for creating, defining, and managing flow definitions
+and commands for running, monitoring, and managing flow runs (also known as
+*actions*).
 
 .. note::
-   This section does not provide details on writing Flows. That is covered
+   This section does not provide details on writing flows. That is covered
    in greater detail in the section on :ref:`flows_authoring`.
 
 Finding and Displaying Flows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When a Flow is deployed to Automate, the creator can specify which identities
-the Flow should be visible to and which identities the Flow should be runnable
-by. As the names suggest, users in a Flow's ``visible_to`` field will be able to
-query the service to view a Flow's definition and metadata. Users in a Flow's
-``runnable_by`` field will be able to run an instance of the Flow.
+When a flow is deployed to Automate, the creator can specify which identities
+the flow should be visible to and which identities the flow should be runnable
+by. As the names suggest, users in a flow's ``visible_to`` field will be able to
+query the service to view a flow's definition and metadata. Users in a flow's
+``runnable_by`` field will be able to run an instance of the flow.
 
-The following command will list the Flows you have created:
+The following command will list the flows you have created:
 
 .. code-block:: BASH
 
     globus-automate flow list
 
-To view Flows which are visible or runnable by you as well, run the following
+To view flows which are visible or runnable by you as well, run the following
 command:
 
 .. code-block:: BASH
 
     globus-automate flow list --role created_by --role visible_to --role runnable_by
 
-This outputs a list of Flows, where the description of each flow carries the
+This outputs a list of flows, where the description of each flow carries the
 same fields as the output from ``globus-automate action introspect`` described
-above. This emphasizes again the similarity between Flows and Actions. The
-``title`` and ``description`` fields may be helpful in determining what a Flow
-does and what its purpose is. Like Actions, the ``input_schema`` may define what
-is required of the input when running the flow. However, not all Flows are
-required to define an ``input_schema`` as a convenience to Flow authors who may
+above. This emphasizes again the similarity between flows and actions. The
+``title`` and ``description`` fields may be helpful in determining what a flow
+does and what its purpose is. Like actions, the ``input_schema`` may define what
+is required of the input when running the flow. However, not all flows are
+required to define an ``input_schema`` as a convenience to flow authors who may
 not be familiar with creating JSON Schema specifications. Importantly, each
-entry in the list of Flows will also contain a value for ``id`` which we refer
-to as the "Flow id" and denote as ``flow_id`` below. This value will be used for
-further interacting with a particular Flow.
+entry in the list of flows will also contain a value for ``id`` which we refer
+to as the "flow id" and denote as ``flow_id`` below. This value will be used for
+further interacting with a particular flow.
 
-To display information about a single Flow you may use:
+To display information about a single flow you may use:
 
 .. code-block:: BASH
 
     globus-automate flow display <flow_id>
 
-Or, to visualize the Flow:
+Or, to visualize the flow:
 
 .. code-block:: BASH
 
     globus-automate flow display <flow_id> --format image
 
-When focusing on one Flow, it is also useful to notice the field ``definition``.
-This is the actual encoding of the Flow as it was created and deployed by the
-Flow's author. Looking at this value may give further information about how the
-Flow works. This can be useful both to determine if a Flow performs the function
-you desire, but also as a method to see how other Flows have been defined if you
-are interested in creating new Flows.
+When focusing on one flow, it is also useful to notice the field ``definition``.
+This is the actual encoding of the flow as it was created and deployed by the
+flow's author. Looking at this value may give further information about how the
+flow works. This can be useful both to determine if a flow performs the function
+you desire, but also as a method to see how other flows have been defined if you
+are interested in creating new flows.
 
 Executing and Monitoring Flows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Execution and monitoring of Flows follows the same pattern as Actions: the
+Execution and monitoring of flows follows the same pattern as actions: the
 run/status/cancel/release pattern is the same.
 
-When initiating a Flow run, you can delegate access to the Flow instance to
+When initiating a flow run, you can delegate access to the flow instance to
 other Globus Auth identities. By providing the ``monitor-by`` option, you can
 delegate read-only access to other users or groups, allowing them to retrieve
 it execution state. By providing the ``manage-by`` option, you delegate write
 access to other users or groups, allowing them to alter its execution state. In
-the example below, we show how to run an instance of a Flow and delegate monitor
+the example below, we show how to run an instance of a flow and delegate monitor
 access to a Globus Group:
 
 .. code-block:: BASH
@@ -459,12 +459,12 @@ access to a Globus Group:
 .. note::
 
     If no ``manage_by`` or ``monitor_by`` values are specified, only the
-    identity instantiating the Flow run is allowed to monitor or manage a Flow's
+    identity instantiating the flow run is allowed to monitor or manage a flow's
     running state.
 
 This acts like ``globus-automate action run`` with the flow id rather than the
-``action_url`` specifying the "name" of the Action to be run. The output, like
-for Actions, will be an Action status document including an ``action_id`` which
+``action_url`` specifying the "name" of the action to be run. The output, like
+for actions, will be an action status document including an ``action_id`` which
 is used in the following commands:
 
 .. code-block:: BASH
@@ -480,10 +480,10 @@ is used in the following commands:
     globus-automate flow action-release --flow-id <flow_id> <action_id>
 
 For each of these, the ``details`` provides information about the most recent,
-potentially final, state executed by the Flow. However, as the Flow may execute
+potentially final, state executed by the flow. However, as the flow may execute
 many states, it is useful to be able to see what states have been executed and
 what their input and output have been. This can be seen via the "log" of the
-Flow execution as follows:
+flow execution as follows:
 
 .. code-block:: BASH
 
@@ -496,71 +496,71 @@ to return. The default value is 10.
 Creating and managing Flows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Many users will only ever use Flows created by others, so they may not
-necessarily need to understand how to create Flows including the commands
-listed in this section. For those that have created a Flow, the first step is
-to deploy a Flow as follows:
+Many users will only ever use flows created by others, so they may not
+necessarily need to understand how to create flows including the commands
+listed in this section. For those that have created a flow, the first step is
+to deploy a flow as follows:
 
 .. code-block:: BASH
 
     globus-automate flow deploy --title <title> \
-        --definition <Flow definition JSON> --input-schema <Input schema JSON> \
-        --visible-to <urn of user or group which can see this Flow> \
-        --runnable-by <urn of user or group which can run this Flow> \
+        --definition <flow definition JSON> --input-schema <Input schema JSON> \
+        --visible-to <urn of user or group which can see this flow> \
+        --runnable-by <urn of user or group which can run this flow> \
         --administered-by <urn of user or group who can maintain this flow>
 
-When deployed this way, only the identity that deployed the Flow will be able to
-view the Flow and only they will be able to run an instance of the Flow. When
-deploying, it's possible to specify who should be able to see and run the Flow.
+When deployed this way, only the identity that deployed the flow will be able to
+view the flow and only they will be able to run an instance of the flow. When
+deploying, it's possible to specify who should be able to see and run the flow.
 Using the ``visible_to`` flag, you can indicate which Globus identities can view
-the deployed Flow, or set it to ``public``, which creates a Flow viewable by
+the deployed flow, or set it to ``public``, which creates a flow viewable by
 anyone. Using the ``runnable_by`` flag, you can indicate which Globus identities
-can run an instance of the deployed Flow, or set a value of
+can run an instance of the deployed flow, or set a value of
 ``all_authenticated_users`` which allows any authenticated user to run an
-instance of the Flow.
+instance of the flow.
 
-Below, we demonstrate how to deploy a Flow that is ``visible_to`` a single
+Below, we demonstrate how to deploy a flow that is ``visible_to`` a single
 Globus group and ``runnable_by`` any authenticated user:
 
 .. code-block:: BASH
 
     globus-automate flow deploy --title <title> \
-        --definition <Flow definition JSON> \
+        --definition <flow definition JSON> \
         --input-schema <Input schema JSON> \
         --visible-to urn:globus:groups:id:00000000-0000-0000-0000-000000000000 \
         --runnable-by all_authenticated_users
 
-Once deployed, the output will be the Flow description as displayed by the
+Once deployed, the output will be the flow description as displayed by the
 ``flow display`` command above. These command line options provide the values
-for the similarly named fields in the Flow description. Of these, only ``title``
-and ``definition`` are required. To aid users in using your Flow, we highly
+for the similarly named fields in the flow description. Of these, only ``title``
+and ``definition`` are required. To aid users in using your flow, we highly
 recommend the use of ``input-schema`` as it provides them both a form of
 documentation and assurance at run-time that the input they provide is correct
-for executing the Flow. By providing a value or values to ``administered-by``
-you grant rights to others for updating or eventually removing the Flow you have
+for executing the flow. By providing a value or values to ``administered-by``
+you grant rights to others for updating or eventually removing the flow you have
 deployed. Commands for updating and removing flows are as follows.
 
 .. code-block:: BASH
 
     globus-automate flow update --title <title> \
-        --definition <Flow definition JSON>  --input-schema <Input schema JSON> \
-        --visible-to <urn of user or group which can see this Flow> \
-        --runnable-by <urn of user or group which can run this Flow> \
+        --definition <flow definition JSON>  --input-schema <Input schema JSON> \
+        --visible-to <urn of user or group which can see this flow> \
+        --runnable-by <urn of user or group which can run this flow> \
         --administered-by <urn of user or group who can maintain this flow> \
         <flow_id>
 
-This will update any of the fields or description of the Flow, including the
-Flow definition itself. Note the ``flow_id`` field is present at the end of the
+This will update any of the fields or description of the flow, including the
+flow definition itself. Note the ``flow_id`` field is present at the end of the
 command line.
 
-Deleting a Flow is done via:
+Deleting a flow is done via:
 
 .. code-block:: BASH
 
     globus-automate flow delete <flow_id>
 
 Care should be taken when issuing this command. There is no further prompting to
-ensure the flow should really be deleted. After deletion, no record of the Flow
+ensure the flow should really be deleted. After deletion, no record of the flow
 definition or its execution history (i.e. the ``flow action-*`` commands) is
 maintained.
 


### PR DESCRIPTION
Includes fixes for uses of “Automate” as well as fixes for capitalization of non-proper nouns and instances where backquotes appear to have been used to indicate emphasis. This is admittedly not comprehensive, so consider this a downpayment on further docs improvements.