### PR TITLE
Add simplified inline flow examples to docs

### DIFF
--- a/changelog.d/20221115_141348_ada_example_updates.rst
+++ b/changelog.d/20221115_141348_ada_example_updates.rst
@@ -1,0 +1,5 @@
+Documentation
+-------------
+
+- Add simplified versions of our production flows as inline examples on the
+  "Authoring Flows" page.


### PR DESCRIPTION
# Background
Our production flows are quite complex and could be difficult for a new author to use as a reference when getting started. This adds simplified versions of these flow definitions as inline examples on the “Authoring Flows” page.

For the purposes of this story, I have largely focused on removing the checks that ensure one of the collections is managed (since a non-subscriber user would need to consume their one free deployed flow, we're okay with this as a substitute limitation) and some explicit error handling that provided defaults when the destination does not exist (as a consequence, now allowing the flow definition to present linearly) as well as reordering the steps to make the definitions easier to read sequentially. I highlighted the production flows in a tip above their corresponding definition to draw users' attention to see a more "complete" example.

# Review
For the purposes of review, I've deployed both flows to production and given you all runner roles:

Two-Stage Transfer: https://app.globus.org/flows/18061a3a-fe67-456e-89b7-dcab09e8b8d2
Move (Transfer and Delete): https://app.globus.org/flows/2594d11a-3584-49d1-b2f4-dcb08a02e71c

For the sake of testing these, I have largely focused on the happy path. If you encounter any unexpected errors, please let me know!