### PR TITLE
Use poetry-core as the build system

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # The automate team will be requested for review on all opened PRs.
-* @globus/automate @ada-globus @joshbryan-globus @kurtmckee @jakeglobus
+* @ada-globus @joshbryan-globus @kurtmckee @jakeglobus @sirosen @derek-globus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,8 @@ profile = "black"
 src_paths = ["globus_automate_client", "examples", "docs", "tests"]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 python_version = "3.6"


### PR DESCRIPTION
This allows tools like `tox` to install mandatory dependencies much more quickly (due to only requiring standalone `poetry-core` instead of `poetry` plus all of its many CLI dependencies).