### PR TITLE
Support getting the flow definition and schema used to start a run

### DIFF
--- a/changelog.d/20230207_143615_kurtmckee.rst
+++ b/changelog.d/20230207_143615_kurtmckee.rst
@@ -1,0 +1,6 @@
+Features
+--------
+
+-   Support retrieval of the flow definition and input schema used to start a run.
+
+    This is supported in the new ``flow run-definition`` subcommand.

--- a/globus_automate_client/action_client.py
+++ b/globus_automate_client/action_client.py
@@ -133,7 +133,7 @@ class ActionClient(BaseClient):
 
     def get_definition(self, action_id: str) -> GlobusHTTPResponse:
         """
-        Query the Action Provider for the status of executed Action
+        Get the flow definition for a given run ID.
 
         :param action_id: An identifier that uniquely identifies an Action
             executed on this Action Provider.

--- a/globus_automate_client/action_client.py
+++ b/globus_automate_client/action_client.py
@@ -131,6 +131,16 @@ class ActionClient(BaseClient):
 
         return self.get(f"{quote(action_id)}/status")
 
+    def get_definition(self, action_id: str) -> GlobusHTTPResponse:
+        """
+        Query the Action Provider for the status of executed Action
+
+        :param action_id: An identifier that uniquely identifies an Action
+            executed on this Action Provider.
+        """
+
+        return self.get(f"/runs/{action_id}/definition")
+
     def resume(self, action_id: str) -> GlobusHTTPResponse:
         """
         Resume an INACTIVE action. Corrective action must have been taken prior to invoking

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -898,6 +898,32 @@ def flow_action_status(
     ).run_and_render()
 
 
+@app.command("run-definition")
+def get_flow_definition_for_run(
+    run_id: str = typer.Argument(...),
+    flow_id: uuid.UUID = typer.Option(
+        ...,
+        help="The ID for the Flow which triggered the Action.",
+    ),
+    flow_scope: str = typer.Option(
+        None,
+        help="The scope this Flow uses to authenticate requests.",
+        callback=url_validator_callback,
+    ),
+    flows_endpoint: str = flows_env_var_option,
+    output_format: OutputFormat = output_format_option,
+    verbose: bool = verbosity_option,
+):
+    """
+    Get the flow definition and input schema used to start a run.
+    """
+    fc = create_flows_client(CLIENT_ID, flows_endpoint)
+    method = functools.partial(
+        fc.get_flow_definition_for_run, flow_id, flow_scope, run_id
+    )
+    RequestRunner(method, format=output_format, verbose=verbose).run_and_render()
+
+
 @app.command("action-resume")
 @app.command("run-resume")
 def flow_action_resume(

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -915,7 +915,7 @@ def get_flow_definition_for_run(
     verbose: bool = verbosity_option,
 ):
     """
-    Get the flow definition and input schema used to start a run.
+    Get the flow definition and input schema used to start this run.
     """
     fc = create_flows_client(CLIENT_ID, flows_endpoint)
     method = functools.partial(

--- a/globus_automate_client/flows_client.py
+++ b/globus_automate_client/flows_client.py
@@ -692,6 +692,29 @@ class FlowsClient(BaseClient):
         ac = ActionClient.new_client(flow_url, authorizer)
         return ac.status(flow_action_id)
 
+    def get_flow_definition_for_run(
+        self, flow_id: str, flow_scope: Optional[str], flow_action_id: str, **kwargs
+    ) -> GlobusHTTPResponse:
+        """
+        Determine the status for an Action that was launched by a Flow
+
+        :param flow_id: The UUID identifying the Flow which triggered the Action
+
+        :param flow_scope: The scope associated with the Flow ``flow_id``. If
+            not provided, the SDK will attempt to perform an introspection on
+            the Flow to determine its scope automatically
+
+        :param flow_action_id: The ID specifying which Action's status to query
+
+        :param kwargs: Any additional kwargs passed into this method are passed
+            onto the Globus BaseClient. If there exists an "authorizer" keyword
+            argument, that gets used to run the Flow operation. Otherwise, the
+            authorizer_callback defined for the FlowsClient will be used.
+        """
+        authorizer = self._get_authorizer_for_flow(flow_id, flow_scope, kwargs)
+        ac = ActionClient.new_client(self.base_url, authorizer)
+        return ac.get_definition(flow_action_id)
+
     def flow_action_resume(
         self, flow_id: str, flow_scope: Optional[str], flow_action_id: str, **kwargs
     ) -> GlobusHTTPResponse:


### PR DESCRIPTION
Features
--------

-   Support retrieval of the flow definition and input schema used to start a run.

    This is supported in the new ``flow run-definition`` subcommand.