### PR TITLE
Prevent passive flow permission updates

### DIFF
--- a/changelog.d/20230314_155142_kurtmckee_prevent_passive_permission_changes_on_flow_update_sc_19291.rst
+++ b/changelog.d/20230314_155142_kurtmckee_prevent_passive_permission_changes_on_flow_update_sc_19291.rst
@@ -1,0 +1,13 @@
+Bugfixes
+--------
+
+-   `[sc-19291] <https://app.shortcut.com/globus/story/19291>`_
+    Prevent passive flow permission updates.
+
+    Previously, permissions were erased during updates if no permissions were specified.
+    Now, permissions will only be erased if an empty string is passed. For example:
+
+    ..  code-block:: text
+
+        # Erase all viewer permissions.
+        globus-automate flow update $UUID --flow-viewer=""

--- a/globus_automate_client/cli/flows.py
+++ b/globus_automate_client/cli/flows.py
@@ -303,51 +303,64 @@ def flow_update(
         "--keyword",
         help="A keyword which may categorize or help discover the Flow. [repeatable]",
     ),
-    flow_viewer: List[str] = typer.Option(
+    flow_viewer: Optional[List[str]] = typer.Option(
         None,
-        help="A principal which may view this Flow. "
-        + _principal_description
-        + "The special value of 'public' may be used to "
-        "indicate that any user can view this Flow. [repeatable]",
-        callback=custom_principal_validator({"public"}),
+        help=(
+            "A principal which may view this flow. "
+            f"{_principal_description} "
+            "\n\nThe special value of 'public' may be used to "
+            "indicate that any user can view this flow. "
+            "\n\nThis option can be used multiple times."
+            "\n\nTo erase any existing viewer permissions, "
+            'use the empty string "" once.'
+        ),
+        callback=custom_principal_validator({"public", ""}),
     ),
     viewer: List[str] = typer.Option(
-        None, callback=custom_principal_validator({"public"}), hidden=True
+        None, callback=custom_principal_validator({"public", ""}), hidden=True
     ),
     visible_to: List[str] = typer.Option(
-        None, callback=custom_principal_validator({"public"}), hidden=True
+        None, callback=custom_principal_validator({"public", ""}), hidden=True
     ),
-    flow_starter: List[str] = typer.Option(
+    flow_starter: Optional[List[str]] = typer.Option(
         None,
-        help="A principal which may run an instance of the deployed Flow. "
-        + _principal_description
-        + " The special value of "
-        "'all_authenticated_users' may be used to indicate that any "
-        "authenticated user can invoke this flow. [repeatable]",
-        callback=custom_principal_validator({"all_authenticated_users"}),
+        help=(
+            "A principal which may start an instance of the flow. "
+            f"{_principal_description}"
+            "\n\nThe special value of 'all_authenticated_users' may be used "
+            "to indicate that any authenticated user can invoke this flow. "
+            "\n\nThis option can be used multiple times."
+            "\n\nTo erase any existing starter permissions, "
+            'use the empty string "" once.'
+        ),
+        callback=custom_principal_validator({"all_authenticated_users", ""}),
     ),
     starter: List[str] = typer.Option(
         None,
-        callback=custom_principal_validator({"all_authenticated_users"}),
+        callback=custom_principal_validator({"all_authenticated_users", ""}),
         hidden=True,
     ),
     runnable_by: List[str] = typer.Option(
         None,
-        callback=custom_principal_validator({"all_authenticated_users"}),
+        callback=custom_principal_validator({"all_authenticated_users", ""}),
         hidden=True,
     ),
-    flow_administrator: List[str] = typer.Option(
+    flow_administrator: Optional[List[str]] = typer.Option(
         None,
-        help="A principal which may update the deployed Flow. "
-        + _principal_description
-        + "[repeatable]",
-        callback=principal_validator,
+        help=(
+            "A principal which may update the deployed Flow. "
+            f"{_principal_description} "
+            "\n\nThis option can be used multiple times."
+            "\n\nTo erase any existing administrator permissions, "
+            'use the empty string "" once.'
+        ),
+        callback=custom_principal_validator({""}),
     ),
     administrator: List[str] = typer.Option(
-        None, callback=principal_validator, hidden=True
+        None, callback=custom_principal_validator({""}), hidden=True
     ),
     administered_by: List[str] = typer.Option(
-        None, callback=principal_validator, hidden=True
+        None, callback=custom_principal_validator({""}), hidden=True
     ),
     subscription_id: Optional[str] = typer.Option(
         None,
@@ -381,6 +394,17 @@ def flow_update(
         ("--flow-administrator", flow_administrator),
         ("--administrator", administrator or None),
         ("--administered-by", administered_by or None),
+    )
+
+    # Special cases:
+    # * If the user specifies a single empty string, replace [""] with []
+    #   so all values currently set on the flow will be erased.
+    # * If the user specifies nothing, replace the default empty list with None
+    #   to prevent erasure of the values currently set on the flow.
+    flow_viewer = [] if flow_viewer == [""] else (flow_viewer or None)
+    flow_starter = [] if flow_starter == [""] else (flow_starter or None)
+    flow_administrator = (
+        [] if flow_administrator == [""] else (flow_administrator or None)
     )
 
     fc = create_flows_client(CLIENT_ID, flows_endpoint)


### PR DESCRIPTION
Bugfixes
--------

-   [\[sc-19291\]](https://app.shortcut.com/globus/story/19291)    Prevent passive flow permission updates.

    Previously, permissions were erased during updates if no permissions were specified.
    Now, permissions will only be erased if an empty string is passed. For example:

    ```text
    # Erase all viewer permissions.
    globus-automate flow update $UUID --flow-viewer=""
    ```
