### PR TITLE
Add a deprecation notice to the top of every HTML page

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,3 +64,22 @@ html_theme = "furo"
 pygments_dark_style = "monokai"
 
 html_static_path = ["_static"]
+
+
+# -- Deprecation notice ------------------------------------------------------
+
+rst_prolog = """
+..  warning::
+
+    The Globus Automate SDK and Globus Automate CLI are deprecated.
+
+    The `Globus SDK`_ and `Globus CLI`_ have integrated their functionality
+    and are able to interact with other Globus services, as well.
+
+    It is strongly recommended that new projects use the Globus SDK and Globus CLI,
+    and that existing projects begin migrating to the Globus SDK and Globus CLI.
+
+..  _Globus SDK: https://globus-sdk-python.readthedocs.io/en/stable/
+..  _Globus CLI: https://docs.globus.org/cli/
+
+"""


### PR DESCRIPTION
This PR introduces a deprecation warning at the top of each HTML page.

It currently renders like this:

![image](https://github.com/globus/globus-automate-client/assets/39996/da745d34-20da-45b0-a4df-6fcdcab8828c)


![image](https://github.com/globus/globus-automate-client/assets/39996/35cbf4e4-a439-41af-a3aa-bd6ff44e3dad)
