### PR TITLE
Introduce a migration doc for globus-sdk and globus-cli usage replacing this library

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,9 +2,7 @@ Globus Automate - CLI and Python SDK
 ====================================
 
 .. toctree::
-   :maxdepth: 1
-   :titlesonly:
-   :caption: Migrating to Globus CLI and GLobus SDK
+   :maxdepth: 2
 
    migration
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,20 @@
 Globus Automate - CLI and Python SDK
 ====================================
 
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+   :caption: Migrating to Globus CLI and GLobus SDK
+
+   migration
+
+----------------
+
+.. warning::
+
+    The Globus Automate Client is deprecated in favor of the Globus CLI and the
+    Globus Python SDK.
+
 This is the command line interface and Python package for working with the Globus
 Flows service and services that implement the Globus Action Provider interface.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,8 +10,9 @@ Globus Automate - CLI and Python SDK
 
 .. warning::
 
-    The Globus Automate Client is deprecated in favor of the Globus CLI and the
-    Globus Python SDK.
+    The Globus Automate Client is deprecated in favor of the
+    `Globus CLI <https://docs.globus.org/cli/>`_ and the
+    `Globus Python SDK <https://globus-sdk-python.readthedocs.io/en/stable/>`_.
 
 This is the command line interface and Python package for working with the Globus
 Flows service and services that implement the Globus Action Provider interface.

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -1,0 +1,101 @@
+Migration to globus-sdk and globus-cli
+======================================
+
+The Globus Automate Client has been deprecated.
+All functionality is now available in `globus-sdk`_ and
+`globus-cli`_.
+
+This document covers how usages and commands from Globus Automate Client can be
+converted to use the new tools.
+
+Translation Tables
+==================
+
+These tables provide summary information on how commands can be translated.
+
+CLI Translation
+---------------
+
+In several cases, multiple commands translate to one command or one command translates to one
+command.
+
+In particular, the `globus-automate` CLI has several redundancies, all of which are explained as
+aliases of one another.
+This explanation is used in a few cases where the commands have very slightly different behavior but
+are functionally aliases.
+
++-------------------------------------------+--------------------------------------+---------------------------+
+| Old Command(s)                            | New Command(s)                       | Explanation               |
++===========================================+======================================+===========================+
+| ``globus-automate queues``                | N/A                                  | No longer supported.      |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate action``                | N/A                                  | No longer supported.      |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate session``               | ``globus login``                     |                           |
+|                                           | ``globus logout``                    |                           |
+|                                           | ``globus whoami``                    |                           |
+|                                           | ``globus session``                   |                           |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow action-cancel``    | ``globus flows run cancel``          | The ``globus-automate``   |
+| ``globus-automate flow run-cancel``       |                                      | commands were aliases of  |
+|                                           |                                      | one another. There is     |
+|                                           |                                      | now only one command.     |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow action-enumerate`` | ``globus flows run list``            | The ``globus-automate``   |
+| ``globus-automate flow action-list``      |                                      | commands were aliases of  |
+| ``globus-automate flow run-enumerate``    |                                      | one another. There is     |
+| ``globus-automate flow run-list``         |                                      | now only one command.     |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow action-log``       | ``globus flows run show-logs``       | The ``globus-automate``   |
+| ``globus-automate flow run-log``          |                                      | commands were aliases of  |
+|                                           |                                      | one another. There is     |
+|                                           |                                      | now only one command.     |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow action-release``   | ``globus flows run delete``          | The ``globus-automate``   |
+| ``globus-automate flow run-release``      |                                      | commands were aliases of  |
+|                                           |                                      | one another. There is     |
+|                                           |                                      | now only one command.     |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow action-resume``    | ``globus flows run resume``          | The ``globus-automate``   |
+| ``globus-automate flow run-resume``       |                                      | commands were aliases of  |
+|                                           |                                      | one another. There is     |
+|                                           |                                      | now only one command.     |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow action-status``    | ``globus flows run show``            | The ``globus-automate``   |
+| ``globus-automate flow run-status``       |                                      | commands were aliases of  |
+|                                           |                                      | one another. There is     |
+|                                           |                                      | now only one command.     |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow action-update``    | ``globus flows run update``          | The ``globus-automate``   |
+| ``globus-automate flow run-update``       |                                      | commands were aliases of  |
+|                                           |                                      | one another. There is     |
+|                                           |                                      | now only one command.     |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow batch-run-update`` | N/A                                  | No longer supported.      |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow delete``           | ``globus flows delete``              |                           |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow deploy``           | ``globus flows create``              |                           |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow display``          | N/A                                  | No longer supported.      |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow get``              | ``globus flows show``                |                           |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow lint``             | N/A                                  | No longer supported.      |
+|                                           |                                      | Validation is now the     |
+|                                           |                                      | responsibility of the     |
+|                                           |                                      | service.                  |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow list``             | ``globus flows list``                |                           |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow run``              | ``globus flows start``               |                           |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow run-definition``   | ``globus flows run show-definition`` |                           |
++-------------------------------------------+--------------------------------------+---------------------------+
+| ``globus-automate flow update``           | ``globus flows update``              |                           |
++-------------------------------------------+--------------------------------------+---------------------------+
+
+
+.. _globus-sdk: https://globus-sdk-python.readthedocs.io/en/stable/
+
+.. _globus-cli: https://docs.globus.org/cli/

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -1,7 +1,7 @@
 Migration to globus-sdk and globus-cli
 ======================================
 
-The Globus Automate Client has been deprecated.
+The Globus Automate Client is deprecated.
 All functionality is now available in `globus-sdk`_ and
 `globus-cli`_.
 
@@ -233,9 +233,9 @@ Usage
 In order to convert a flow from YAML to JSON using ``yq``, all that is needed
 is a command which loads the YAML document and then outputs it as JSON.
 
-.. code-block:: bash
+.. code-block:: console
 
-    yq -o=json foo.yaml > foo.json
+    $ yq -o=json foo.yaml > foo.json
 
 remarshal
 ~~~~~~~~~
@@ -276,10 +276,10 @@ Of the many commands provided by ``remarshal``, the one we want is simply
 pyyaml
 ~~~~~~
 
-Unlike the previous two tools, ``pyyaml`` is a python library, not a CLI.
+Unlike the previous two tools, ``pyyaml`` is a Python library, not a CLI.
 
 If you have a YAML flow definition and want to use it with the ``globus-sdk``,
-you must parse it from YAML yourself and proivde it as a dictionary.
+you must parse it from YAML yourself and provide it as a dictionary.
 
 Installation
 ++++++++++++
@@ -291,12 +291,14 @@ Usage
 
 ``pyyaml`` provides the ``yaml`` package.
 To parse a YAML file, ``foo.yaml``, into a python data structure, import it and
-use the ``load`` function::
+use the ``load`` function:
+
+..  code-block:: python
 
     import yaml
 
     with open("foo.yaml") as fp:
-        data = yaml.load(fp)
+        data = yaml.safe_load(fp)
 
     # a check may be a wise precaution, as YAML documents can contain lists or
     # other non-dict data
@@ -336,7 +338,7 @@ For example, ``globus-automate flow deploy`` has been replaced with
 The first step is to determine which CLI options are required and in what
 order. Run ``globus flows create --help`` to see the help text:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ globus flows create --help
     Usage: globus flows create [OPTIONS] TITLE DEFINITION
@@ -368,7 +370,7 @@ which controls the total number of results returned.
 Under ``globus-automate``, users had precise control over pagination, while
 under ``globus-cli`` all pagination is implicitly handled for the user.
 
-The two implementations trade off between simplicity for users vs fine-grained
+The two implementations trade off between simplicity for users versus fine-grained
 control, and are not fully translatable.
 For users, simply note that ``--marker`` and ``-per-page`` are no longer
 available as options, but that users relying on these options should now have
@@ -463,7 +465,7 @@ SDK Migration and ``create_flows_client``
 The ``create_flows_client`` helper has no singular replacement.
 
 Instead, users should expect to write a small block of code to correctly
-authenticate pass the resulting authorizer to the matching client clas.  See
+authenticate and pass the resulting authorizer to the matching client class.  See
 `the globus-sdk example usage
 <https://globus-sdk-python.readthedocs.io/en/stable/examples/create_and_run_flow/>`_ for
 an example of how to do this.
@@ -474,7 +476,7 @@ Why was this removed?
 The ``create_flows_client`` helper attempts to consolidate functionality across
 a disparate set of concerns.
 However, implementers attempting to build applications on top of the Globus
-Flows API need finer grained control than could be provided through this
+Flows API need finer-grained control than could be provided through this
 interface.
 This removal reflects the same restructuring of client code which separates the
 ``FlowsClient`` and ``SpecificFlowClient`` classes, as these two classes

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -179,6 +179,135 @@ mapping of methods for the ``FlowsClient``.
 +-----------------------------------------------+--------------------------------------+
 
 
+Converting YAML to JSON
+-----------------------
+
+In the Globus Automate Client, users were allowed to use YAML files to define
+their flows.
+However, the Flows service only accepts JSON data, and YAML was being converted
+to JSON by the client.
+
+Unfortunately, the YAML language specification contains ambiguities, and
+different parsers may treat identical documents differently.
+``globus-cli`` and ``globus-sdk`` do not support YAML parsing, but it is possible
+to convert YAML to JSON using a variety of tools.
+This approach ensures that Globus provided software operates consistently, and
+allows users to continue using YAML or to move off of it, as they prefer.
+
+In this section, we will cover two popular tools for converting YAML to JSON,
+yq (written in Go) and remarshal (written in Python). We will also cover
+one python library, ``pyyaml``, which can be used to load YAML data and pass it
+to the ``globus-sdk``.
+Various other tools provide similar functionality in other languages, and there
+are alternative parsers available in python.
+
+yq
+~~
+
+The `yq <https://mikefarah.gitbook.io/yq/>`_ tool is a CLI utility similar to the
+popular ``jq`` command.
+It provides a wide variety of commands for manipulating and extracting data
+from YAML documents.
+
+Installation
+++++++++++++
+
+``yq`` is distributed for multiple platforms as a binary as well as Homebrew
+and Snapcraft.
+For these latter two, use:
+
+.. code-block:: bash
+
+    # macOS, brew
+    brew install yq
+
+    # ubuntu-based linux, snap
+    snap install yq
+
+To get a ``yq`` binary directly, or to use the docker based distribution,
+follow
+`yq's installation instructions <https://github.com/mikefarah/yq/#install>`_.
+
+Usage
++++++
+
+In order to convert a flow from YAML to JSON using ``yq``, all that is needed
+is a command which loads the YAML document and then outputs it as JSON.
+
+.. code-block:: bash
+
+    yq -o=json foo.yaml > foo.json
+
+remarshal
+~~~~~~~~~
+
+The `remarshal <https://github.com/remarshal-project/remarshal>`_ project
+provides a wide range of commands for converting data between different
+formats, including YAML and JSON.
+
+These commands exist for the sole purpose of converting data between formats,
+and are therefore a perfect fit for our use-case.
+
+Installation
+++++++++++++
+
+As ``remarshal`` is a python CLI, installation should be performed with
+``pipx``, as with the ``globus-cli``.
+
+First `follow the pipx installation documentation
+<https://pypa.github.io/pipx/installation/>`_ to ensure you have ``pipx``
+installed.
+
+Next, run the install command:
+
+.. code-block:: bash
+
+    pipx install remarshal
+
+Usage
++++++
+
+Of the many commands provided by ``remarshal``, the one we want is simply
+``yaml2json``. After installing, all that is needed is to run:
+
+.. code-block:: bash
+
+    yaml2json foo.yaml foo.json
+
+pyyaml
+~~~~~~
+
+Unlike the previous two tools, ``pyyaml`` is a python library, not a CLI.
+
+If you have a YAML flow definition and want to use it with the ``globus-sdk``,
+you must parse it from YAML yourself and proivde it as a dictionary.
+
+Installation
+++++++++++++
+
+``pyyaml`` can be installed with ``pip install pyyaml``.
+
+Usage
++++++
+
+``pyyaml`` provides the ``yaml`` package.
+To parse a YAML file, ``foo.yaml``, into a python data structure, import it and
+use the ``load`` function::
+
+    import yaml
+
+    with open("foo.yaml") as fp:
+        data = yaml.load(fp)
+
+    # a check may be a wise precaution, as YAML documents can contain lists or
+    # other non-dict data
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"YAML document 'foo.yaml' contained unexpected type {type(data)}"
+        )
+
+    print(data)
+
 .. [*] ``scopes`` is an instance attribute of ``SpecificFlowClient``, so usage is
     slightly different from a method, but the information provided is the same.
 

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -200,43 +200,6 @@ to the ``globus-sdk``.
 Various other tools provide similar functionality in other languages, and there
 are alternative parsers available in python.
 
-yq
-~~
-
-The `yq <https://mikefarah.gitbook.io/yq/>`_ tool is a CLI utility similar to the
-popular ``jq`` command.
-It provides a wide variety of commands for manipulating and extracting data
-from YAML documents.
-
-Installation
-++++++++++++
-
-``yq`` is distributed for multiple platforms as a binary as well as Homebrew
-and Snapcraft.
-For these latter two, use:
-
-.. code-block:: bash
-
-    # macOS, brew
-    brew install yq
-
-    # ubuntu-based linux, snap
-    snap install yq
-
-To get a ``yq`` binary directly, or to use the docker based distribution,
-follow
-`yq's installation instructions <https://github.com/mikefarah/yq/#install>`_.
-
-Usage
-+++++
-
-In order to convert a flow from YAML to JSON using ``yq``, all that is needed
-is a command which loads the YAML document and then outputs it as JSON.
-
-.. code-block:: console
-
-    $ yq -o=json foo.yaml > foo.json
-
 remarshal
 ~~~~~~~~~
 
@@ -247,21 +210,10 @@ formats, including YAML and JSON.
 These commands exist for the sole purpose of converting data between formats,
 and are therefore a perfect fit for our use-case.
 
-Installation
-++++++++++++
-
 As ``remarshal`` is a python CLI, installation should be performed with
 ``pipx``, as with the ``globus-cli``.
-
-First `follow the pipx installation documentation
-<https://pypa.github.io/pipx/installation/>`_ to ensure you have ``pipx``
-installed.
-
-Next, run the install command:
-
-.. code-block:: bash
-
-    pipx install remarshal
+For full instructions, follow `remsarhsal's installation documentation
+<https://github.com/remarshal-project/remarshal#installation>`_.
 
 Usage
 +++++
@@ -269,9 +221,30 @@ Usage
 Of the many commands provided by ``remarshal``, the one we want is simply
 ``yaml2json``. After installing, all that is needed is to run:
 
-.. code-block:: bash
+.. code-block:: console
 
-    yaml2json foo.yaml foo.json
+    $ yaml2json foo.yaml foo.json
+
+yq
+~~
+
+The `yq <https://mikefarah.gitbook.io/yq/>`_ tool is a CLI utility similar to the
+popular ``jq`` command.
+It provides a wide variety of commands for manipulating and extracting data
+from YAML documents.
+
+`yq's installation instructions <https://github.com/mikefarah/yq/#install>`_
+cover installation.
+
+Usage
++++++
+
+In order to convert a flow from YAML to JSON using ``yq``, all that is needed
+is a command which loads the YAML document and then outputs it as JSON.
+
+.. code-block:: console
+
+    $ yq -o=json foo.yaml > foo.json
 
 pyyaml
 ~~~~~~
@@ -291,7 +264,7 @@ Usage
 
 ``pyyaml`` provides the ``yaml`` package.
 To parse a YAML file, ``foo.yaml``, into a python data structure, import it and
-use the ``load`` function:
+use the ``safe_load`` function:
 
 ..  code-block:: python
 
@@ -299,13 +272,6 @@ use the ``load`` function:
 
     with open("foo.yaml") as fp:
         data = yaml.safe_load(fp)
-
-    # a check may be a wise precaution, as YAML documents can contain lists or
-    # other non-dict data
-    if not isinstance(data, dict):
-        raise ValueError(
-            f"YAML document 'foo.yaml' contained unexpected type {type(data)}"
-        )
 
     print(data)
 
@@ -322,18 +288,18 @@ the two, for commands and usages where the mapping is non-obvious.
 Required Options vs Positional Arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In general, the ``globus-cli`` uses positional arguments for all required
+In general, the ``globus`` CLI uses positional arguments for all required
 data, whereas the ``globus-automate`` CLI used required options in some cases.
 
 The conversion is typically straightforward, requiring first that you read the
-``globus-cli`` helptext and then order arguments appropriately if necessary.
+``globus`` CLI helptext and then order arguments appropriately if necessary.
 
 For example, ``globus-automate flow deploy`` has been replaced with
 ``globus flows create``. Starting from an original command like so:
 
-.. code-block:: bash
+.. code-block:: console
 
-    $ globus-automate flow deploy --description bar --title foo --definition foo.json
+    $ globus-automate flow deploy --input-schema '{}' --title foo --definition foo.json
 
 The first step is to determine which CLI options are required and in what
 order. Run ``globus flows create --help`` to see the help text:
@@ -350,25 +316,25 @@ order. Run ``globus flows create --help`` to see the help text:
     ...
 
 With this information, we can see that ``TITLE`` is the first positional
-argument and ``DEFINITION`` is the second. ``--description`` is still an
+argument and ``DEFINITION`` is the second. ``--input-schema`` is still an
 option.
 
 The final command is therefore:
 
 .. code-block:: bash
 
-    globus flows create foo foo.json --description bar
+    globus flows create foo foo.json --input-schema '{}'
 
 Pagination Options
 ~~~~~~~~~~~~~~~~~~
 
 A number of ``globus-automate`` commands provide options for paging through
 data, typically ``--marker`` and ``--per-page``.
-In ``globus-cli``, these options are replaced with a single option ``--limit``,
-which controls the total number of results returned.
+In the ``globus`` CLI, these options are replaced with a single option
+``--limit``, which controls the total number of results returned.
 
 Under ``globus-automate``, users had precise control over pagination, while
-under ``globus-cli`` all pagination is implicitly handled for the user.
+under the ``globus`` CLI all pagination is implicitly handled for the user.
 
 The two implementations trade off between simplicity for users versus fine-grained
 control, and are not fully translatable.
@@ -383,7 +349,7 @@ commands.
 Under the ``globus-automate`` CLI several commands took a ``--flow-scope``
 option to control internal behaviors.
 
-This option is no longer needed, as the ``globus-cli`` will automatically
+This option is no longer needed, as the ``globus`` CLI will automatically
 handle the cases which this option covered.
 
 ``run-log --watch``
@@ -398,7 +364,7 @@ service by polling.
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ``globus-automate flow run-resume`` accepted two options which are not present
-in the ``globus-cli``.
+in the ``globus`` CLI.
 
 One option is ``--watch``, which is identical to the ``run-status --watch``
 flag.

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -9,92 +9,178 @@ This document covers how usages and commands from Globus Automate Client can be
 converted to use the new tools.
 
 Translation Tables
-==================
+------------------
 
 These tables provide summary information on how commands can be translated.
 
 CLI Translation
----------------
+~~~~~~~~~~~~~~~
 
 In several cases, multiple commands translate to one command or one command translates to one
 command.
 
-In particular, the `globus-automate` CLI has several redundancies, all of which are explained as
-aliases of one another.
-This explanation is used in a few cases where the commands have very slightly different behavior but
-are functionally aliases.
+In particular, the ``globus-automate`` CLI has a number of redundancies and
+aliases, which are replaced with singular commands in `globus-cli`_.
 
-+-------------------------------------------+--------------------------------------+---------------------------+
-| Old Command(s)                            | New Command(s)                       | Explanation               |
-+===========================================+======================================+===========================+
-| ``globus-automate queues``                | N/A                                  | No longer supported.      |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate action``                | N/A                                  | No longer supported.      |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate session``               | ``globus login``                     |                           |
-|                                           | ``globus logout``                    |                           |
-|                                           | ``globus whoami``                    |                           |
-|                                           | ``globus session``                   |                           |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow action-cancel``    | ``globus flows run cancel``          | The ``globus-automate``   |
-| ``globus-automate flow run-cancel``       |                                      | commands were aliases of  |
-|                                           |                                      | one another. There is     |
-|                                           |                                      | now only one command.     |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow action-enumerate`` | ``globus flows run list``            | The ``globus-automate``   |
-| ``globus-automate flow action-list``      |                                      | commands were aliases of  |
-| ``globus-automate flow run-enumerate``    |                                      | one another. There is     |
-| ``globus-automate flow run-list``         |                                      | now only one command.     |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow action-log``       | ``globus flows run show-logs``       | The ``globus-automate``   |
-| ``globus-automate flow run-log``          |                                      | commands were aliases of  |
-|                                           |                                      | one another. There is     |
-|                                           |                                      | now only one command.     |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow action-release``   | ``globus flows run delete``          | The ``globus-automate``   |
-| ``globus-automate flow run-release``      |                                      | commands were aliases of  |
-|                                           |                                      | one another. There is     |
-|                                           |                                      | now only one command.     |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow action-resume``    | ``globus flows run resume``          | The ``globus-automate``   |
-| ``globus-automate flow run-resume``       |                                      | commands were aliases of  |
-|                                           |                                      | one another. There is     |
-|                                           |                                      | now only one command.     |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow action-status``    | ``globus flows run show``            | The ``globus-automate``   |
-| ``globus-automate flow run-status``       |                                      | commands were aliases of  |
-|                                           |                                      | one another. There is     |
-|                                           |                                      | now only one command.     |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow action-update``    | ``globus flows run update``          | The ``globus-automate``   |
-| ``globus-automate flow run-update``       |                                      | commands were aliases of  |
-|                                           |                                      | one another. There is     |
-|                                           |                                      | now only one command.     |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow batch-run-update`` | N/A                                  | No longer supported.      |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow delete``           | ``globus flows delete``              |                           |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow deploy``           | ``globus flows create``              |                           |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow display``          | N/A                                  | No longer supported.      |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow get``              | ``globus flows show``                |                           |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow lint``             | N/A                                  | No longer supported.      |
-|                                           |                                      | Validation is now the     |
-|                                           |                                      | responsibility of the     |
-|                                           |                                      | service.                  |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow list``             | ``globus flows list``                |                           |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow run``              | ``globus flows start``               |                           |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow run-definition``   | ``globus flows run show-definition`` |                           |
-+-------------------------------------------+--------------------------------------+---------------------------+
-| ``globus-automate flow update``           | ``globus flows update``              |                           |
-+-------------------------------------------+--------------------------------------+---------------------------+
+Additionally, several commands from the ``globus-automate`` CLI are mapped to
+"N/A", meaning they have no new equivalents.
+These commands refer to fully deprecated functionality or functionality which
+is now provided in a completely different way -- for example,
+``globus-automate flow lint`` provided logic which is now incorporated into the
+Globus Flows service as part of *flow* creation.
 
++-------------------------------------------+--------------------------------------+
+| Old Command(s)                            | New Command(s)                       |
++===========================================+======================================+
+| ``globus-automate queues``                | N/A                                  |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate action``                | N/A                                  |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate session``               | ``globus login``                     |
+|                                           |                                      |
+|                                           | ``globus logout``                    |
+|                                           |                                      |
+|                                           | ``globus whoami``                    |
+|                                           |                                      |
+|                                           | ``globus session``                   |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow action-cancel``    | ``globus flows run cancel``          |
+|                                           |                                      |
+| ``globus-automate flow run-cancel``       |                                      |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow action-enumerate`` | ``globus flows run list``            |
+|                                           |                                      |
+| ``globus-automate flow action-list``      |                                      |
+|                                           |                                      |
+| ``globus-automate flow run-enumerate``    |                                      |
+|                                           |                                      |
+| ``globus-automate flow run-list``         |                                      |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow action-log``       | ``globus flows run show-logs``       |
+|                                           |                                      |
+| ``globus-automate flow run-log``          |                                      |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow action-release``   | ``globus flows run delete``          |
+|                                           |                                      |
+| ``globus-automate flow run-release``      |                                      |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow action-resume``    | ``globus flows run resume``          |
+|                                           |                                      |
+| ``globus-automate flow run-resume``       |                                      |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow action-status``    | ``globus flows run show``            |
+|                                           |                                      |
+| ``globus-automate flow run-status``       |                                      |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow action-update``    | ``globus flows run update``          |
+|                                           |                                      |
+| ``globus-automate flow run-update``       |                                      |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow batch-run-update`` | N/A                                  |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow delete``           | ``globus flows delete``              |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow deploy``           | ``globus flows create``              |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow display``          | N/A                                  |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow get``              | ``globus flows show``                |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow lint``             | N/A                                  |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow list``             | ``globus flows list``                |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow run``              | ``globus flows start``               |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow run-definition``   | ``globus flows run show-definition`` |
++-------------------------------------------+--------------------------------------+
+| ``globus-automate flow update``           | ``globus flows update``              |
++-------------------------------------------+--------------------------------------+
+
+SDK Translation
+~~~~~~~~~~~~~~~
+
+The Globus Automate Client's functionality as a python library is primarily
+provided by the following four components, which map onto different components
+in the Globus SDK:
+
++-------------------------------------------+--------------------------------------+
+| ``globus_automate_client`` Component      | ``globus_sdk`` Component             |
++===========================================+======================================+
+| ``ActionClient``                          | N/A                                  |
++-------------------------------------------+--------------------------------------+
+| ``FlowsClient``                           | ``FlowsClient``                      |
+|                                           |                                      |
+|                                           | ``SpecificFlowClient``               |
++-------------------------------------------+--------------------------------------+
+| ``create_action_client``                  | N/A                                  |
++-------------------------------------------+--------------------------------------+
+| ``create_flows_client``                   | ``tokenstorage``                     |
+|                                           |                                      |
+|                                           | ``NativeAppAuthClient`` or           |
+|                                           | ``ConfidentialAppAuthClient``        |
+|                                           |                                      |
+|                                           | ``FlowsClient`` or                   |
+|                                           | ``SpecificFlowClient``               |
++-------------------------------------------+--------------------------------------+
+
+The ``ActionClient`` is effectively removed, and the ``FlowsClient`` is split
+in two.
+
+The ``create_flow_client`` helper has no singular replacement. Instead, users
+should expect to write a small block of code to correctly authenticate pass the
+resulting authorizer to the matching client class. See `the globus-sdk example
+usage <https://gist.github.com/sirosen/c7dd9fd00a41b7a4fc6b1c79d84d2eaf>`_ for
+an example of how to do this.
+
+In addition to the high-level component mapping, it's valuable to enumerate the
+mapping of methods for the ``FlowsClient``.
+
++-----------------------------------------------+--------------------------------------+
+| ``globus_automate_client.FlowsClient`` Method | ``globus_sdk`` Method                |
++===============================================+======================================+
+| ``deploy_flow``                               | ``FlowsClient.create_flow``          |
++-----------------------------------------------+--------------------------------------+
+| ``update_flow``                               | ``FlowsClient.update_flow``          |
++-----------------------------------------------+--------------------------------------+
+| ``get_flow``                                  | ``FlowsClient.get_flow``             |
++-----------------------------------------------+--------------------------------------+
+| ``list_flows``                                | ``FlowsClient.list_flows``           |
++-----------------------------------------------+--------------------------------------+
+| ``delete_flow``                               | ``FlowsClient.delete_flow``          |
++-----------------------------------------------+--------------------------------------+
+| ``flow_action_status``                        | ``FlowsClient.get_run``              |
++-----------------------------------------------+--------------------------------------+
+| ``get_flow_definition_for_run``               | ``FlowsClient.get_run_definition``   |
++-----------------------------------------------+--------------------------------------+
+| ``flow_action_release``                       | ``FlowsClient.delete_run``           |
++-----------------------------------------------+--------------------------------------+
+| ``flow_action_cancel``                        | ``FlowsClient.cancel_run``           |
++-----------------------------------------------+--------------------------------------+
+| ``enumerate_runs``                            | ``FlowsClient.list_runs``            |
+|                                               |                                      |
+| ``enumerate_actions``                         |                                      |
+|                                               |                                      |
+| ``list_flow_actions``                         |                                      |
+|                                               |                                      |
+| ``list_flow_runs``                            |                                      |
++-----------------------------------------------+--------------------------------------+
+| ``flow_action_update``                        | ``FlowsClient.update_run``           |
++-----------------------------------------------+--------------------------------------+
+| ``update_runs``                               | N/A                                  |
++-----------------------------------------------+--------------------------------------+
+| ``flow_action_log``                           | ``FlowsClient.get_run_logs``         |
++-----------------------------------------------+--------------------------------------+
+| ``scope_for_flow``                            | ``SpecificFlowClient.scopes`` [*]_   |
++-----------------------------------------------+--------------------------------------+
+| ``flow_action_resume``                        | ``SpecificFlowClient.resume_run``    |
++-----------------------------------------------+--------------------------------------+
+| ``run_flow``                                  | ``SpecificFlowClient.run_flow``      |
++-----------------------------------------------+--------------------------------------+
+
+
+.. [*] ``scopes`` is an instance attribute of ``SpecificFlowClient``, so usage is
+    slightly different from a method, but the information provided is the same.
 
 .. _globus-sdk: https://globus-sdk-python.readthedocs.io/en/stable/
 

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -212,7 +212,7 @@ and are therefore a perfect fit for our use-case.
 
 As ``remarshal`` is a python CLI, installation should be performed with
 ``pipx``, as with the ``globus-cli``.
-For full instructions, follow `remsarhsal's installation documentation
+For full instructions, follow `remarshal's installation documentation
 <https://github.com/remarshal-project/remarshal#installation>`_.
 
 Usage

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -129,11 +129,8 @@ in the Globus SDK:
 The ``ActionClient`` is effectively removed, and the ``FlowsClient`` is split
 in two.
 
-The ``create_flow_client`` helper has no singular replacement. Instead, users
-should expect to write a small block of code to correctly authenticate pass the
-resulting authorizer to the matching client class. See `the globus-sdk example
-usage <https://gist.github.com/sirosen/c7dd9fd00a41b7a4fc6b1c79d84d2eaf>`_ for
-an example of how to do this.
+For details on how ``create_flows_client`` has been replaced, see the
+:ref:`section below <migrate_create_flows_client>` on this topic.
 
 In addition to the high-level component mapping, it's valuable to enumerate the
 mapping of methods for the ``FlowsClient``.
@@ -458,6 +455,45 @@ This ``--watch`` flag is another instance of the same behavior described above.
 Users needing to poll on run status can use ``globus flows run show`` as in the
 preceding example.
 
+.. _migrate_create_flows_client:
+
+SDK Migration and ``create_flows_client``
+-----------------------------------------
+
+The ``create_flows_client`` helper has no singular replacement.
+
+Instead, users should expect to write a small block of code to correctly
+authenticate pass the resulting authorizer to the matching client clas.  See
+`the globus-sdk example usage
+<https://globus-sdk-python.readthedocs.io/en/stable/examples/create_and_run_flow/>`_ for
+an example of how to do this.
+
+Why was this removed?
+~~~~~~~~~~~~~~~~~~~~~
+
+The ``create_flows_client`` helper attempts to consolidate functionality across
+a disparate set of concerns.
+However, implementers attempting to build applications on top of the Globus
+Flows API need finer grained control than could be provided through this
+interface.
+This removal reflects the same restructuring of client code which separates the
+``FlowsClient`` and ``SpecificFlowClient`` classes, as these two classes
+represent different authentication contexts.
+
+There are also more minor issues which were obscured by the helper.
+For example, ``globus-automate-client`` included its own client, meaning that all
+users using the ``create_flows_client`` helper were authenticating against a
+singular client application.
+Under the ``globus-sdk``, users are expected to create their own client,
+allowing them to set Globus Auth fields for that client for terms and
+conditions, login policy, and other features.
+
+The design of the ``globus-sdk`` tends towards fewer holistic helpers and more
+pluggable components.
+This means that although `tokenstorage
+<https://globus-sdk-python.readthedocs.io/en/stable/tokenstorage.html>`_ is
+described as a replacement for ``create_flows_client``, it only covers a very
+specific subset of the functionality.
 
 .. [*] ``scopes`` is an instance attribute of ``SpecificFlowClient``, so usage is
     slightly different from a method, but the information provided is the same.

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -102,7 +102,7 @@ Globus Flows service as part of *flow* creation.
 SDK Translation
 ~~~~~~~~~~~~~~~
 
-The Globus Automate Client's functionality as a python library is primarily
+The Globus Automate Client's functionality as a Python library is primarily
 provided by the following four components, which map onto different components
 in the Globus SDK:
 
@@ -195,10 +195,10 @@ allows users to continue using YAML or to move off of it, as they prefer.
 
 In this section, we will cover two popular tools for converting YAML to JSON,
 yq (written in Go) and remarshal (written in Python). We will also cover
-one python library, ``pyyaml``, which can be used to load YAML data and pass it
+one Python library, ``pyyaml``, which can be used to load YAML data and pass it
 to the ``globus-sdk``.
 Various other tools provide similar functionality in other languages, and there
-are alternative parsers available in python.
+are alternative parsers available in Python.
 
 remarshal
 ~~~~~~~~~
@@ -210,7 +210,7 @@ formats, including YAML and JSON.
 These commands exist for the sole purpose of converting data between formats,
 and are therefore a perfect fit for our use-case.
 
-As ``remarshal`` is a python CLI, installation should be performed with
+As ``remarshal`` is a Python CLI, installation should be performed with
 ``pipx``, as with the ``globus-cli``.
 For full instructions, follow `remarshal's installation documentation
 <https://github.com/remarshal-project/remarshal#installation>`_.
@@ -263,7 +263,7 @@ Usage
 +++++
 
 ``pyyaml`` provides the ``yaml`` package.
-To parse a YAML file, ``foo.yaml``, into a python data structure, import it and
+To parse a YAML file, ``foo.yaml``, into a Python data structure, import it and
 use the ``safe_load`` function:
 
 ..  code-block:: python


### PR DESCRIPTION
This PR should stay in draft until a CLI release provides the features which are currently in `main` and an SDK release contains the Create & Run Flow example.

---

The guide doc covers the following sections:
- map CLI commands (in a table)
- map SDK methods (in a table)
- reshaping YAML into JSON[^1]; loading YAML with pyyaml
- detailed guidance regarding all converted options
- detailed guidance on replacing `create_flows_client`

I have tried to refrain from editorializing or providing more context than is necessarily _useful_ to the user.
The only clear exception to this rule is `create_flows_client`, in which case I felt that we need to justify at some level the apparent loss of functionality -- in fact, replacing troubling functionality with something in which we have more confidence as maintainers.

[^1]: I earlier said I would document Miller, but I learned that it doesn't have YAML support yet. I chose `yq` as a replacement. My goal was to find a suitable option in Go or Rust, to provide a non-python option with a smooth installation experience.