### PR TITLE
Update black pre-commit hook URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: check-github-workflows
       - id: check-dependabot
 
-  - repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.7.0
     hooks:
     - id: black-jupyter


### PR DESCRIPTION

Update the black pre-commit URL.

## How this change was made
This change was made using the following script:

```python
import pathlib
import sys

path = pathlib.Path(".pre-commit-config.yaml")
if not path.is_file():
    sys.exit(0)

text = path.read_text()
if "https://github.com/psf/black-pre-commit-mirror" in text:
    sys.exit(0)

for repo in ("https://github.com/psf/black", "https://github.com/python/black"):
    text = text.replace(f"{repo}", f"https://github.com/psf/black-pre-commit-mirror")
path.write_text(text)
```


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>